### PR TITLE
fix: LPフッターにリーガルリンク追加 + Google Search Console対応

### DIFF
--- a/frontend/src/app/[locale]/_components/Footer/Footer.module.css
+++ b/frontend/src/app/[locale]/_components/Footer/Footer.module.css
@@ -87,6 +87,44 @@
   filter: invert(1);
 }
 
+/* ── リーガルリンク区切り線（SP のみ）── */
+
+.legalSeparator {
+  width: 100%;
+  height: 1px;
+  background: var(--lp-cta-signup-text);
+  opacity: 0.3;
+  margin: 10px 0;
+}
+
+/* ── リーガルリンク ── */
+
+.legal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.legalLink {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--lp-cta-signup-text);
+  opacity: 0.6;
+  text-decoration: none;
+  letter-spacing: 1px;
+}
+
+.legalLink:hover {
+  opacity: 1;
+}
+
+.legalLink:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 4px;
+}
+
 /* ── PC (min-width: 768px) ── */
 
 @media (min-width: 768px) {
@@ -106,6 +144,19 @@
 
   .links {
     width: auto;
+    justify-content: flex-end;
+  }
+
+  .legalSeparator {
+    display: none;
+  }
+
+  .inner {
+    flex-wrap: wrap;
+  }
+
+  .legal {
+    width: 100%;
     justify-content: flex-end;
   }
 }

--- a/frontend/src/app/[locale]/_components/Footer/index.tsx
+++ b/frontend/src/app/[locale]/_components/Footer/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import styles from "./Footer.module.css";
 
@@ -69,6 +70,20 @@ export async function Footer({ locale }: FooterProps) {
               />
             </a>
           </div>
+        </div>
+
+        <div className={styles.legalSeparator} />
+
+        <div className={styles.legal}>
+          <Link href={`/${locale}/terms`} className={styles.legalLink}>
+            {t("terms")}
+          </Link>
+          <Link href={`/${locale}/privacy`} className={styles.legalLink}>
+            {t("privacy")}
+          </Link>
+          <Link href={`/${locale}/tokushoho`} className={styles.legalLink}>
+            {t("tokushoho")}
+          </Link>
         </div>
       </div>
     </footer>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -52,6 +52,9 @@ export const metadata: Metadata = {
       "x-default": "/",
     },
   },
+  verification: {
+    google: "lJSJzbsvC9niACrdNQRB-C2m2AWjmCZHnrPPtlbHEtY",
+  },
   manifest: "/manifest.json",
   themeColor: "#2C2C2C",
   appleWebApp: {

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -178,7 +178,10 @@
       "contact": "Contact",
       "instagram": "Instagram",
       "facebook": "Facebook",
-      "backToTop": "Back to top"
+      "backToTop": "Back to top",
+      "terms": "Terms of Service",
+      "privacy": "Privacy Policy",
+      "tokushoho": "Specified Commercial Transactions Act"
     }
   },
   "language": {

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -178,7 +178,10 @@
       "contact": "お問い合わせ",
       "instagram": "Instagram",
       "facebook": "Facebook",
-      "backToTop": "トップに戻る"
+      "backToTop": "トップに戻る",
+      "terms": "利用規約",
+      "privacy": "プライバシーポリシー",
+      "tokushoho": "特定商取引法に基づく表記"
     }
   },
   "language": {


### PR DESCRIPTION
## Summary
- Google検証botがハンバーガーメニュー内のリンクを認識できない問題に対応し、LPフッターに利用規約・プライバシーポリシー・特定商取引法に基づく表記のリンクを直接配置
- Google Search Console所有権確認用のメタタグ（`google-site-verification`）をルートレイアウトに追加
- Supabase Redirect URLsに `https://aikinote.com/auth/callback` を追加済み（Appleサインイン不具合の原因と思われる設定漏れ）

## Test plan
- [x] LP（`/` および `/en`）のフッターに利用規約・プライバシーポリシー・特定商取引法のリンクが表示されること
- [x] SP/PC両方でレイアウトが崩れないこと
- [x] 各リンクから `/ja/terms`, `/ja/privacy`, `/ja/tokushoho` に正しく遷移すること
- [ ] HTMLソースに `<meta name="google-site-verification" ...>` が出力されていること
- [ ] Google Search Consoleで所有権確認がPASSすること
- [x] Appleサインインが正常に動作すること（Supabase設定修正後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)