### PR TITLE
fix: ボタン内スピナーのサイズを縮小

### DIFF
--- a/frontend/src/app/[locale]/(public)/login/Login.tsx
+++ b/frontend/src/app/[locale]/(public)/login/Login.tsx
@@ -231,7 +231,7 @@ export function Login({ locale, onSuccess }: LoginProps) {
               className={`${styles.button} ${styles.emailSubmitButton}`}
             >
               {isProcessing ? (
-                <Loader size="small" text={t("auth.loginInProgress")} />
+                <Loader size="xs" text={t("auth.loginInProgress")} />
               ) : (
                 t("auth.loginButton")
               )}

--- a/frontend/src/app/[locale]/(public)/signup/SignUp.tsx
+++ b/frontend/src/app/[locale]/(public)/signup/SignUp.tsx
@@ -319,7 +319,7 @@ export function SignUp({ locale, onSuccess }: SignUpProps) {
               className={`${styles.button} ${styles.emailSubmitButton}`}
             >
               {isProcessing ? (
-                <Loader size="small" text={t("auth.processing")} />
+                <Loader size="xs" text={t("auth.processing")} />
               ) : (
                 t("auth.signupWithEmail")
               )}
@@ -382,7 +382,7 @@ export function SignUp({ locale, onSuccess }: SignUpProps) {
                 disabled={isProcessing}
               >
                 {isProcessing ? (
-                  <Loader size="small" text={t("auth.creating")} />
+                  <Loader size="xs" text={t("auth.creating")} />
                 ) : (
                   t("auth.next")
                 )}

--- a/frontend/src/components/features/auth/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/frontend/src/components/features/auth/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -126,7 +126,7 @@ export function ForgotPasswordForm({ onSuccess }: ForgotPasswordFormProps) {
           className={`${styles.button} ${styles.primaryButton}`}
         >
           {isProcessing ? (
-            <Loader size="small" text={t("auth.sending")} />
+            <Loader size="xs" text={t("auth.sending")} />
           ) : (
             t("auth.sendResetEmail")
           )}

--- a/frontend/src/components/features/auth/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/src/components/features/auth/ResetPasswordForm/ResetPasswordForm.tsx
@@ -164,7 +164,7 @@ export function ResetPasswordForm({
           className={`${styles.button} ${styles.primaryButton}`}
         >
           {isProcessing ? (
-            <Loader size="small" text={t("auth.changing")} />
+            <Loader size="xs" text={t("auth.changing")} />
           ) : (
             t("auth.changePassword")
           )}

--- a/frontend/src/components/shared/Loader/Loader.module.css
+++ b/frontend/src/components/shared/Loader/Loader.module.css
@@ -30,6 +30,13 @@
   border-width: 3px;
 }
 
+/* ボタン内用の極小サイズ */
+.xs .spinner {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+}
+
 /* 中央揃えコンテナ */
 .centered {
   position: fixed;

--- a/frontend/src/components/shared/Loader/Loader.tsx
+++ b/frontend/src/components/shared/Loader/Loader.tsx
@@ -3,7 +3,7 @@ import styles from "./Loader.module.css";
 
 export interface LoaderProps {
   /** ローダーのサイズ */
-  size?: "small" | "medium" | "large";
+  size?: "xs" | "small" | "medium" | "large";
   /** 中央揃えにするかどうか */
   centered?: boolean;
   /** 表示するテキスト */


### PR DESCRIPTION
## Summary
- Loaderコンポーネントに `xs` サイズ（16px）を追加
- ボタン内で使用しているスピナー5箇所を `small`（32px）→ `xs`（16px）に変更
- ボタンのサイズに対してスピナーが大きすぎた問題を修正

## Test plan
- [ ] ログインボタン押下時のスピナーサイズが適切であること
- [ ] 新規登録ボタン押下時のスピナーサイズが適切であること
- [ ] パスワードリセット・変更ボタン押下時のスピナーサイズが適切であること
- [ ] 他のLoader（ページ読み込み等）のサイズが変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)