### PR TITLE
fix: 未ログイン時にヘッダーナビゲーションを非表示にする

### DIFF
--- a/frontend/src/app/[locale]/(public)/login/Login.tsx
+++ b/frontend/src/app/[locale]/(public)/login/Login.tsx
@@ -231,7 +231,7 @@ export function Login({ locale, onSuccess }: LoginProps) {
               className={`${styles.button} ${styles.emailSubmitButton}`}
             >
               {isProcessing ? (
-                <Loader size="small" text={t("auth.loginInProgress")} />
+                <Loader size="xs" text={t("auth.loginInProgress")} />
               ) : (
                 t("auth.loginButton")
               )}

--- a/frontend/src/app/[locale]/(public)/signup/SignUp.tsx
+++ b/frontend/src/app/[locale]/(public)/signup/SignUp.tsx
@@ -319,7 +319,7 @@ export function SignUp({ locale, onSuccess }: SignUpProps) {
               className={`${styles.button} ${styles.emailSubmitButton}`}
             >
               {isProcessing ? (
-                <Loader size="small" text={t("auth.processing")} />
+                <Loader size="xs" text={t("auth.processing")} />
               ) : (
                 t("auth.signupWithEmail")
               )}
@@ -382,7 +382,7 @@ export function SignUp({ locale, onSuccess }: SignUpProps) {
                 disabled={isProcessing}
               >
                 {isProcessing ? (
-                  <Loader size="small" text={t("auth.creating")} />
+                  <Loader size="xs" text={t("auth.creating")} />
                 ) : (
                   t("auth.next")
                 )}

--- a/frontend/src/components/features/auth/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/frontend/src/components/features/auth/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -126,7 +126,7 @@ export function ForgotPasswordForm({ onSuccess }: ForgotPasswordFormProps) {
           className={`${styles.button} ${styles.primaryButton}`}
         >
           {isProcessing ? (
-            <Loader size="small" text={t("auth.sending")} />
+            <Loader size="xs" text={t("auth.sending")} />
           ) : (
             t("auth.sendResetEmail")
           )}

--- a/frontend/src/components/features/auth/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/src/components/features/auth/ResetPasswordForm/ResetPasswordForm.tsx
@@ -164,7 +164,7 @@ export function ResetPasswordForm({
           className={`${styles.button} ${styles.primaryButton}`}
         >
           {isProcessing ? (
-            <Loader size="small" text={t("auth.changing")} />
+            <Loader size="xs" text={t("auth.changing")} />
           ) : (
             t("auth.changePassword")
           )}

--- a/frontend/src/components/shared/Loader/Loader.module.css
+++ b/frontend/src/components/shared/Loader/Loader.module.css
@@ -30,6 +30,13 @@
   border-width: 3px;
 }
 
+/* ボタン内用の極小サイズ */
+.xs .spinner {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+}
+
 /* 中央揃えコンテナ */
 .centered {
   position: fixed;

--- a/frontend/src/components/shared/Loader/Loader.tsx
+++ b/frontend/src/components/shared/Loader/Loader.tsx
@@ -3,7 +3,7 @@ import styles from "./Loader.module.css";
 
 export interface LoaderProps {
   /** ローダーのサイズ */
-  size?: "small" | "medium" | "large";
+  size?: "xs" | "small" | "medium" | "large";
   /** 中央揃えにするかどうか */
   centered?: boolean;
   /** 表示するテキスト */

--- a/frontend/src/components/shared/layouts/common/DefaultHeader/DefaultHeader.tsx
+++ b/frontend/src/components/shared/layouts/common/DefaultHeader/DefaultHeader.tsx
@@ -137,30 +137,32 @@ export const DefaultHeader: FC<DefaultHeaderProps> = ({
       </Link>
 
       <div className={styles.headerRight}>
-        <nav className={styles.desktopNav}>
-          <Link
-            href={`/${locale}/personal/pages`}
-            className={`${styles.desktopNavLink} ${activeTab === "personal" ? styles.desktopNavLinkActive : ""}`}
-          >
-            <PencilSimpleIcon size={18} weight="light" />
-            {t("components.personal")}
-          </Link>
-          <Link
-            href={`/${locale}/social/posts`}
-            className={`${styles.desktopNavLink} ${activeTab === "social" ? styles.desktopNavLinkActive : ""}`}
-          >
-            <ChatsIcon size={18} weight="light" />
-            {t("components.group")}
-            {unreadCount > 0 && <span className={styles.desktopNavBadge} />}
-          </Link>
-          <Link
-            href={`/${locale}/mypage`}
-            className={`${styles.desktopNavLink} ${activeTab === "mypage" ? styles.desktopNavLinkActive : ""}`}
-          >
-            <IdentificationCardIcon size={18} weight="light" />
-            {t("components.mypage")}
-          </Link>
-        </nav>
+        {user && (
+          <nav className={styles.desktopNav}>
+            <Link
+              href={`/${locale}/personal/pages`}
+              className={`${styles.desktopNavLink} ${activeTab === "personal" ? styles.desktopNavLinkActive : ""}`}
+            >
+              <PencilSimpleIcon size={18} weight="light" />
+              {t("components.personal")}
+            </Link>
+            <Link
+              href={`/${locale}/social/posts`}
+              className={`${styles.desktopNavLink} ${activeTab === "social" ? styles.desktopNavLinkActive : ""}`}
+            >
+              <ChatsIcon size={18} weight="light" />
+              {t("components.group")}
+              {unreadCount > 0 && <span className={styles.desktopNavBadge} />}
+            </Link>
+            <Link
+              href={`/${locale}/mypage`}
+              className={`${styles.desktopNavLink} ${activeTab === "mypage" ? styles.desktopNavLinkActive : ""}`}
+            >
+              <IdentificationCardIcon size={18} weight="light" />
+              {t("components.mypage")}
+            </Link>
+          </nav>
+        )}
 
         {showUserSection && user && (
           <div ref={profileCardRef} className={styles.profileCardWrapper}>


### PR DESCRIPTION
## Summary
- DefaultHeaderのデスクトップナビゲーション（ひとりで/みんなで/マイページ）が `user` の有無に関係なく常に表示されていたバグを修正
- `{user && (...)}` で囲み、未ログイン時はナビゲーションを非表示にする

## Test plan
- [ ] 未ログイン状態でログイン画面・新規登録画面にアクセスし、ヘッダーにナビゲーションが表示されないこと
- [ ] ログイン済み状態でヘッダーにナビゲーションが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)