### PR TITLE
fix: 返信者のプロフィール画像・ユーザー名からプロフィール画面に遷移できるようにする

### DIFF
--- a/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.module.css
+++ b/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.module.css
@@ -17,10 +17,47 @@
   margin-bottom: 4px;
 }
 
-.username {
+.authorLink {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.authorButton {
+  display: flex;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.authorNameLink {
   font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--black);
+  line-height: 1.3;
+  text-decoration: none;
+}
+
+.authorNameLink:hover {
+  text-decoration: underline;
+}
+
+.authorNameButton {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--black);
+  line-height: 1.3;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  letter-spacing: normal;
+}
+
+.authorNameButton:hover {
+  text-decoration: underline;
 }
 
 .timestamp {

--- a/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.test.tsx
+++ b/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { I18nTestProvider } from "@/test-utils/i18n-test-provider";
+import { SocialReplyItem } from "./SocialReplyItem";
+
+const socialPostsMessages = {
+  components: {
+    profileImage: "プロフィール画像",
+  },
+  socialPosts: {
+    edited: "編集済み",
+    menuEdit: "編集",
+    menuDelete: "削除",
+    menuReport: "通報",
+    editCancel: "キャンセル",
+    editSave: "保存",
+    favorite: "お気に入り",
+    reportReplyTitle: "返信を通報",
+    deleteReplyConfirm: "この返信を削除しますか？",
+  },
+};
+
+const replierId = "replier-42";
+const replierUsername = "hanako_budo";
+
+const baseReply = {
+  id: "reply-1",
+  user_id: replierId,
+  content: "素晴らしい稽古記録ですね！",
+  favorite_count: 0,
+  created_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+  user: {
+    id: replierId,
+    username: replierUsername,
+    profile_image_url: null,
+  },
+  is_favorited: false,
+};
+
+function renderReply(
+  overrides: Partial<React.ComponentProps<typeof SocialReplyItem>> = {},
+) {
+  const props: React.ComponentProps<typeof SocialReplyItem> = {
+    reply: baseReply,
+    currentUserId: "viewer-1",
+    isAuthenticated: true,
+    onReport: vi.fn(),
+    onEdit: vi.fn(async () => {}),
+    onDelete: vi.fn(async () => {}),
+    onFavoriteToggle: vi.fn(),
+    onUnauthenticatedAction: vi.fn(),
+    ...overrides,
+  };
+
+  render(
+    <I18nTestProvider messages={socialPostsMessages}>
+      <SocialReplyItem {...props} />
+    </I18nTestProvider>,
+  );
+
+  return props;
+}
+
+describe("SocialReplyItem", () => {
+  it("認証済みユーザーには返信者ユーザー名が /social/profile/[user_id] へのリンクとして描画される", () => {
+    // Arrange & Act
+    renderReply();
+
+    // Assert
+    const usernameLink = screen.getByRole("link", { name: replierUsername });
+    expect(usernameLink).toHaveAttribute(
+      "href",
+      `/ja/social/profile/${replierId}`,
+    );
+  });
+
+  it("認証済みユーザーには返信者プロフィール画像もプロフィール画面リンクとして描画される", () => {
+    // Arrange & Act
+    renderReply();
+
+    // Assert
+    const profileLinks = screen
+      .getAllByRole("link")
+      .filter(
+        (el) => el.getAttribute("href") === `/ja/social/profile/${replierId}`,
+      );
+    expect(profileLinks).toHaveLength(2);
+  });
+
+  it("未認証ユーザーが返信者のユーザー名をタップするとonUnauthenticatedActionが呼ばれる", async () => {
+    // Arrange
+    const onUnauthenticatedAction = vi.fn();
+    renderReply({ isAuthenticated: false, onUnauthenticatedAction });
+
+    // Act
+    await userEvent.click(
+      screen.getByRole("button", { name: replierUsername }),
+    );
+
+    // Assert
+    expect(onUnauthenticatedAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("未認証ユーザーが返信者のプロフィール画像をタップするとonUnauthenticatedActionが呼ばれる", async () => {
+    // Arrange
+    const onUnauthenticatedAction = vi.fn();
+    renderReply({ isAuthenticated: false, onUnauthenticatedAction });
+
+    // Act
+    const buttons = screen.getAllByRole("button");
+    const imageButton = buttons.find((btn) =>
+      btn.querySelector("img, svg, [class*='profileImage']"),
+    );
+    expect(imageButton).toBeDefined();
+    await userEvent.click(imageButton as HTMLElement);
+
+    // Assert
+    expect(onUnauthenticatedAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("未認証ユーザー向けの描画ではプロフィールリンクは存在しない", () => {
+    // Arrange & Act
+    renderReply({ isAuthenticated: false });
+
+    // Assert
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.tsx
+++ b/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.tsx
@@ -2,7 +2,7 @@
 
 import { DotsThreeVerticalIcon, HeartIcon } from "@phosphor-icons/react";
 import dynamic from "next/dynamic";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { type FC, memo, useCallback, useEffect, useRef, useState } from "react";
 
 const ReportModal = dynamic(
@@ -64,6 +64,11 @@ export const SocialReplyItem: FC<SocialReplyItemProps> = memo(
     onUnauthenticatedAction,
   }) {
     const t = useTranslations("socialPosts");
+    const locale = useLocale();
+    const profileHref = `/${locale}/social/profile/${reply.user.id}`;
+    const handleUnauthenticatedProfileClick = useCallback(() => {
+      onUnauthenticatedAction?.();
+    }, [onUnauthenticatedAction]);
     const isOwner = reply.user_id === currentUserId;
     const [showMenu, setShowMenu] = useState(false);
     const [showReportModal, setShowReportModal] = useState(false);
@@ -145,10 +150,34 @@ export const SocialReplyItem: FC<SocialReplyItemProps> = memo(
 
     return (
       <div className={styles.reply}>
-        <ProfileImage src={reply.user.profile_image_url} size="small" />
+        {isAuthenticated ? (
+          <a href={profileHref} className={styles.authorLink}>
+            <ProfileImage src={reply.user.profile_image_url} size="small" />
+          </a>
+        ) : (
+          <button
+            type="button"
+            className={styles.authorButton}
+            onClick={handleUnauthenticatedProfileClick}
+          >
+            <ProfileImage src={reply.user.profile_image_url} size="small" />
+          </button>
+        )}
         <div className={styles.replyContent}>
           <div className={styles.replyHeader}>
-            <span className={styles.username}>{reply.user.username}</span>
+            {isAuthenticated ? (
+              <a href={profileHref} className={styles.authorNameLink}>
+                {reply.user.username}
+              </a>
+            ) : (
+              <button
+                type="button"
+                className={styles.authorNameButton}
+                onClick={handleUnauthenticatedProfileClick}
+              >
+                {reply.user.username}
+              </button>
+            )}
             <span className={styles.timestamp}>
               {formatToRelativeTime(reply.created_at)}
             </span>


### PR DESCRIPTION
## Summary

- 投稿一覧・投稿詳細では投稿者のプロフィール画像／ユーザー名タップで `/social/profile/[user_id]` に遷移できるが、**返信**側は同じ要素が遷移しなかったため、挙動を揃えた
- 認証済みユーザーは `<a>` でプロフィール画面へ、未認証ユーザーは既存の新規登録プロンプトを発火（投稿詳細の投稿者リンクと同じパターン）
- AAA パターンの単体テスト 5 ケースを新規追加（認証時の href 検証、未認証時のコールバック発火、リンク非表示の確認）

## Test plan

- [x] 認証済みで投稿詳細を開き、返信のプロフィール画像／ユーザー名タップで `/social/profile/[返信者ID]` に遷移できる
- [x] 未認証で同じ操作を行うと、新規登録プロンプトモーダルが開く（投稿者側と同挙動）
- [x] SP 幅（375px）でレイアウト崩れ・タップ領域の不具合がない
- [x] 自分の返信／他人の返信／編集済み／お気に入り済み／削除されたエントリの各状態でリグレッションがない

🤖 Generated with [Claude Code](https://claude.com/claude-code)