### PR TITLE
feat: みんなで投稿時の公開範囲確認ダイアログを実装

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/social/posts/SocialPostsFeed.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/SocialPostsFeed.tsx
@@ -17,6 +17,7 @@ import { FloatingActionButton } from "@/components/shared/FloatingActionButton/F
 import { Loader } from "@/components/shared/Loader/Loader";
 import { SocialLayout } from "@/components/shared/layouts/SocialLayout";
 import { PremiumUpgradeModal } from "@/components/shared/PremiumUpgradeModal/PremiumUpgradeModal";
+import { PublicityConfirmDialog } from "@/components/shared/PublicityConfirmDialog/PublicityConfirmDialog";
 import { useToast } from "@/contexts/ToastContext";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useDailyLimits } from "@/lib/hooks/useDailyLimits";
@@ -26,6 +27,7 @@ import { useSwipeNavigation } from "@/lib/hooks/useSwipeNavigation";
 import { useUmamiTrack } from "@/lib/hooks/useUmamiTrack";
 import { useUnreadReplyPostIds } from "@/lib/hooks/useUnreadNotificationCount";
 import { Link, useRouter } from "@/lib/i18n/routing";
+import { usePublicityConfirmStore } from "@/stores/publicityConfirmStore";
 import styles from "./page.module.css";
 
 const VALID_TABS: SocialTab[] = ["all", "training", "favorites"];
@@ -57,6 +59,8 @@ export function SocialPostsFeed() {
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [upgradeModalKey, setUpgradeModalKey] =
     useState<string>("premiumModalBrowse");
+  const { hasConfirmedPublicity } = usePublicityConfirmStore();
+  const [showPublicityDialog, setShowPublicityDialog] = useState(false);
 
   const updateTab = useCallback((tab: SocialTab) => {
     setActiveTab(tab);
@@ -200,15 +204,18 @@ export function SocialPostsFeed() {
       </div>
 
       <FloatingActionButton
-        href={canPost ? `/${locale}/social/posts/new` : undefined}
-        onClick={
-          !canPost
-            ? () => {
-                setUpgradeModalKey("premiumModalDailyLimit");
-                setShowUpgradeModal(true);
-              }
-            : undefined
-        }
+        onClick={() => {
+          if (!canPost) {
+            setUpgradeModalKey("premiumModalDailyLimit");
+            setShowUpgradeModal(true);
+            return;
+          }
+          if (!hasConfirmedPublicity) {
+            setShowPublicityDialog(true);
+            return;
+          }
+          router.push("/social/posts/new");
+        }}
         label={t("createPost")}
       />
 
@@ -219,6 +226,15 @@ export function SocialPostsFeed() {
           setUpgradeModalKey("premiumModalBrowse");
         }}
         translationKey={upgradeModalKey}
+      />
+
+      <PublicityConfirmDialog
+        isOpen={showPublicityDialog}
+        onCancel={() => setShowPublicityDialog(false)}
+        onConfirm={() => {
+          setShowPublicityDialog(false);
+          router.push("/social/posts/new");
+        }}
       />
     </SocialLayout>
   );

--- a/frontend/src/components/shared/PublicityConfirmDialog/PublicityConfirmDialog.module.css
+++ b/frontend/src/components/shared/PublicityConfirmDialog/PublicityConfirmDialog.module.css
@@ -1,0 +1,230 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--overlay-scrim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: var(--z-confirm);
+}
+
+.dialog {
+  background-color: var(--white);
+  width: 100%;
+  max-width: 340px;
+  border-radius: 8px;
+  padding: 20px;
+  border: 0.5px solid var(--border-color);
+  box-shadow: 0 8px 24px rgba(44, 44, 44, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-base);
+  text-align: center;
+  color: var(--black);
+  letter-spacing: 0.06em;
+}
+
+.description {
+  font-size: var(--font-size-sm);
+  color: var(--black);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* アコーディオン */
+.accordionSection {
+  border-top: 0.5px solid var(--border-color);
+  padding-top: 12px;
+}
+
+.accordionToggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  color: var(--black);
+  font-weight: 500;
+}
+
+.accordionContent {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  margin-top: 8px;
+  background-color: var(--bg-base);
+  border-radius: 6px;
+}
+
+/* 公開範囲ラジオボタン */
+.radioGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.radioOption {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.radioLabel {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background-color: var(--white);
+  transition: border-color 0.15s;
+}
+
+.radioLabel:has(input:checked) {
+  border-color: var(--primary-color);
+}
+
+.radioInput {
+  accent-color: var(--primary-color);
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.radioContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.radioTitle {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--black);
+}
+
+.radioDescription {
+  font-size: var(--font-size-xs);
+  color: var(--text-light);
+  line-height: 1.4;
+}
+
+/* closed 時の道場選択 */
+.closedDojoSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dojoAddRow {
+  position: relative;
+}
+
+.noDojoWarning {
+  font-size: var(--font-size-xs);
+  color: var(--error-color);
+  margin: 0;
+}
+
+.selectedDojoList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dojoChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  background-color: var(--white);
+  font-family: var(--font-ui);
+}
+
+.dojoChipName {
+  font-size: var(--font-size-xs);
+  color: var(--black);
+}
+
+.dojoChipRemove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-light);
+  cursor: pointer;
+}
+
+.defaultBadge {
+  font-size: var(--font-size-xs);
+  color: var(--text-light);
+}
+
+/* チェックボックス */
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox {
+  accent-color: var(--primary-color);
+  flex-shrink: 0;
+}
+
+.checkboxLabel {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--text-light);
+  cursor: pointer;
+}
+
+/* アクションボタン */
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  border-top: 0.5px solid var(--border-color);
+  padding-top: 16px;
+}
+
+.actionButton {
+  min-width: auto;
+  width: 100%;
+}
+
+@media (min-width: 431px) {
+  .dialog {
+    padding: 24px;
+    max-width: 380px;
+  }
+
+  .actionButton {
+    width: auto;
+    min-width: 120px;
+  }
+}

--- a/frontend/src/components/shared/PublicityConfirmDialog/PublicityConfirmDialog.tsx
+++ b/frontend/src/components/shared/PublicityConfirmDialog/PublicityConfirmDialog.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { CaretDown, CaretRight, X } from "@phosphor-icons/react";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useId, useState } from "react";
+import { createPortal } from "react-dom";
+import { Button } from "@/components/shared/Button/Button";
+import {
+  DojoStyleAutocomplete,
+  type DojoStyleOption,
+} from "@/components/shared/DojoStyleAutocomplete/DojoStyleAutocomplete";
+import { Loader } from "@/components/shared/Loader/Loader";
+import {
+  getPublicityDojos,
+  getUserInfo,
+  updatePublicityDojos,
+  updateUserInfo,
+} from "@/lib/api/client";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { usePublicityConfirmStore } from "@/stores/publicityConfirmStore";
+import styles from "./PublicityConfirmDialog.module.css";
+
+type PublicityValue = "public" | "closed" | "private";
+
+const PUBLICITY_OPTIONS: PublicityValue[] = ["public", "closed", "private"];
+
+interface DojoEntry {
+  id: string;
+  dojo_name: string;
+}
+
+interface PublicityConfirmDialogProps {
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function PublicityConfirmDialog({
+  isOpen,
+  onCancel,
+  onConfirm,
+}: PublicityConfirmDialogProps) {
+  const { user } = useAuth();
+  const t = useTranslations();
+  const groupId = useId();
+  const titleId = useId();
+  const checkboxId = useId();
+  const { setHasConfirmedPublicity } = usePublicityConfirmStore();
+
+  const [isAccordionOpen, setIsAccordionOpen] = useState(false);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  // 公開範囲の状態
+  const [value, setValue] = useState<PublicityValue>("public");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [userDojo, setUserDojo] = useState<DojoEntry | null>(null);
+  const [selectedDojos, setSelectedDojos] = useState<DojoEntry[]>([]);
+  const [dojoSearchValue, setDojoSearchValue] = useState("");
+  const [dojoSearchId, setDojoSearchId] = useState<string | null>(null);
+
+  // ダイアログが開かれたときにデータを取得
+  useEffect(() => {
+    if (!isOpen || !user?.id) return;
+    setIsLoading(true);
+    const fetchData = async () => {
+      try {
+        const [userResult, dojosResult] = await Promise.all([
+          getUserInfo(user.id),
+          getPublicityDojos(user.id),
+        ]);
+
+        if (userResult.success && userResult.data) {
+          const setting = userResult.data.publicity_setting;
+          if (
+            setting === "public" ||
+            setting === "closed" ||
+            setting === "private"
+          ) {
+            setValue(setting);
+          }
+          if (
+            userResult.data.dojo_style_id &&
+            userResult.data.dojo_style_name
+          ) {
+            setUserDojo({
+              id: userResult.data.dojo_style_id,
+              dojo_name: userResult.data.dojo_style_name,
+            });
+          }
+        }
+
+        if (dojosResult.success && dojosResult.data) {
+          setSelectedDojos(
+            dojosResult.data.map((d) => ({
+              id: d.dojo_style_id,
+              dojo_name: d.dojo_name,
+            })),
+          );
+        }
+      } catch (error) {
+        console.error("公開範囲設定取得エラー:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [isOpen, user?.id]);
+
+  const handleValueChange = (newValue: PublicityValue) => {
+    setValue(newValue);
+    if (newValue === "closed" && userDojo) {
+      setSelectedDojos((prev) => {
+        if (prev.some((d) => d.id === userDojo.id)) return prev;
+        return [userDojo, ...prev];
+      });
+    }
+  };
+
+  const handleDojoSelect = (dojoStyle: DojoStyleOption) => {
+    setSelectedDojos((prev) => {
+      if (prev.some((d) => d.id === dojoStyle.id)) return prev;
+      return [...prev, { id: dojoStyle.id, dojo_name: dojoStyle.dojo_name }];
+    });
+    setDojoSearchValue("");
+    setDojoSearchId(null);
+  };
+
+  const handleDojoRemove = (dojoId: string) => {
+    if (dojoId === userDojo?.id) return;
+    setSelectedDojos((prev) => prev.filter((d) => d.id !== dojoId));
+  };
+
+  const handleConfirm = useCallback(async () => {
+    if (isSaving) return;
+
+    if (dontShowAgain) {
+      setHasConfirmedPublicity(true);
+    }
+
+    // "public" 以外が選択されている場合のみ API で更新
+    if (value !== "public" && user?.id) {
+      setIsSaving(true);
+      try {
+        if (value === "closed") {
+          await updatePublicityDojos(
+            user.id,
+            selectedDojos.map((d) => d.id),
+          );
+        }
+        const result = await updateUserInfo({
+          userId: user.id,
+          publicity_setting: value,
+        });
+        if (!result.success) {
+          throw new Error(t("publicityConfirmDialog.saveFailed"));
+        }
+      } catch (error) {
+        console.error("公開範囲設定更新エラー:", error);
+        setIsSaving(false);
+        return;
+      }
+      setIsSaving(false);
+    }
+
+    onConfirm();
+  }, [
+    isSaving,
+    dontShowAgain,
+    value,
+    user?.id,
+    selectedDojos,
+    setHasConfirmedPublicity,
+    t,
+    onConfirm,
+  ]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className={styles.overlay}>
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
+        <h2 id={titleId} className={styles.title}>
+          {t("publicityConfirmDialog.title")}
+        </h2>
+
+        <p className={styles.description}>
+          {t("publicityConfirmDialog.description")}
+        </p>
+
+        {/* アコーディオン: 公開範囲を確認する */}
+        <div className={styles.accordionSection}>
+          <button
+            type="button"
+            className={styles.accordionToggle}
+            onClick={() => setIsAccordionOpen((prev) => !prev)}
+            aria-expanded={isAccordionOpen}
+          >
+            {isAccordionOpen ? (
+              <CaretDown size={14} weight="bold" color="var(--black)" />
+            ) : (
+              <CaretRight size={14} weight="bold" color="var(--black)" />
+            )}
+            <span>{t("publicityConfirmDialog.accordionLabel")}</span>
+          </button>
+
+          {isAccordionOpen && (
+            <div className={styles.accordionContent}>
+              {isLoading ? (
+                <Loader centered size="small" />
+              ) : (
+                <div
+                  className={styles.radioGroup}
+                  role="radiogroup"
+                  aria-labelledby={groupId}
+                >
+                  {PUBLICITY_OPTIONS.map((option) => (
+                    <div key={option} className={styles.radioOption}>
+                      <label className={styles.radioLabel}>
+                        <input
+                          type="radio"
+                          name="publicity-confirm"
+                          value={option}
+                          checked={value === option}
+                          onChange={() => handleValueChange(option)}
+                          className={styles.radioInput}
+                        />
+                        <div className={styles.radioContent}>
+                          <span className={styles.radioTitle}>
+                            {t(`publicitySetting.${option}`)}
+                          </span>
+                          <span className={styles.radioDescription}>
+                            {t(`publicitySetting.${option}Description`)}
+                          </span>
+                        </div>
+                      </label>
+
+                      {option === "closed" && value === "closed" && (
+                        <div className={styles.closedDojoSection}>
+                          {!userDojo && (
+                            <p className={styles.noDojoWarning}>
+                              {t("publicitySetting.noDojoWarning")}
+                            </p>
+                          )}
+
+                          <div className={styles.dojoAddRow}>
+                            <DojoStyleAutocomplete
+                              value={dojoSearchValue}
+                              onChange={setDojoSearchValue}
+                              onSelect={handleDojoSelect}
+                              placeholder={t(
+                                "publicitySetting.addDojoPlaceholder",
+                              )}
+                              selectedId={dojoSearchId}
+                              onClear={() => {
+                                setDojoSearchValue("");
+                                setDojoSearchId(null);
+                              }}
+                            />
+                          </div>
+
+                          {selectedDojos.length > 0 && (
+                            <div className={styles.selectedDojoList}>
+                              {selectedDojos.map((dojo) => (
+                                <div key={dojo.id} className={styles.dojoChip}>
+                                  <span className={styles.dojoChipName}>
+                                    {dojo.dojo_name}
+                                  </span>
+                                  {dojo.id === userDojo?.id ? (
+                                    <span className={styles.defaultBadge}>
+                                      {t("publicitySetting.defaultDojo")}
+                                    </span>
+                                  ) : (
+                                    <button
+                                      type="button"
+                                      className={styles.dojoChipRemove}
+                                      onClick={() => handleDojoRemove(dojo.id)}
+                                      aria-label={`${dojo.dojo_name} を削除`}
+                                    >
+                                      <X size={14} />
+                                    </button>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* 今後は表示しない */}
+        <div className={styles.checkboxRow}>
+          <input
+            type="checkbox"
+            id={checkboxId}
+            checked={dontShowAgain}
+            onChange={(e) => setDontShowAgain(e.target.checked)}
+            className={styles.checkbox}
+          />
+          <label htmlFor={checkboxId} className={styles.checkboxLabel}>
+            {t("publicityConfirmDialog.dontShowAgain")}
+          </label>
+        </div>
+
+        {/* アクションボタン */}
+        <div className={styles.actions}>
+          <Button
+            variant="cancel"
+            className={styles.actionButton}
+            onClick={onCancel}
+            disabled={isSaving}
+          >
+            {t("publicityConfirmDialog.cancel")}
+          </Button>
+          <Button
+            variant="primary"
+            className={styles.actionButton}
+            onClick={handleConfirm}
+            disabled={isSaving}
+          >
+            {isSaving ? "..." : t("publicityConfirmDialog.confirm")}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/stores/publicityConfirmStore.ts
+++ b/frontend/src/stores/publicityConfirmStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export interface PublicityConfirmState {
+  hasConfirmedPublicity: boolean;
+  setHasConfirmedPublicity: (value: boolean) => void;
+}
+
+export const usePublicityConfirmStore = create<PublicityConfirmState>()(
+  persist(
+    (set) => ({
+      hasConfirmedPublicity: false,
+      setHasConfirmedPublicity: (value) =>
+        set({ hasConfirmedPublicity: value }),
+    }),
+    {
+      name: "aikinote-publicity-confirm",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -941,6 +941,15 @@
     "saved": "Publicity updated",
     "saveFailed": "Failed to update visibility"
   },
+  "publicityConfirmDialog": {
+    "title": "Confirm Visibility",
+    "description": "Unlike creating Personal training log pages, Social posts are visible to other users. You can change your visibility settings anytime from the Visibility Settings page in My Page.",
+    "accordionLabel": "Review visibility settings",
+    "dontShowAgain": "Don't show again",
+    "cancel": "Cancel",
+    "confirm": "Confirmed",
+    "saveFailed": "Failed to update visibility"
+  },
   "mypageContent": {
     "profileSection": "Profile",
     "userInfoSection": "User Info",

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -943,6 +943,15 @@
     "saved": "公開範囲を更新しました",
     "saveFailed": "公開範囲の更新に失敗しました"
   },
+  "publicityConfirmDialog": {
+    "title": "公開範囲の確認",
+    "description": "ひとりで機能の稽古記録ページの作成とは異なり、みんなで機能の投稿内容は他のユーザーにも公開されます。公開範囲を変更したい場合は、マイページの公開範囲設定画面からいつでも変更できます。",
+    "accordionLabel": "公開範囲を確認する",
+    "dontShowAgain": "今後は表示しない",
+    "cancel": "キャンセル",
+    "confirm": "確認しました",
+    "saveFailed": "公開範囲の更新に失敗しました"
+  },
   "mypageContent": {
     "profileSection": "プロフィール",
     "userInfoSection": "ユーザー情報",


### PR DESCRIPTION
## Summary
- 「みんなで」投稿一覧画面のFAB押下時に、公開範囲の確認ダイアログ（PublicityConfirmDialog）を表示する機能を追加
- ダイアログ上で公開範囲の確認・変更が可能。アコーディオン展開で `/settings/publicity` と同等のラジオボタン + 道場選択UIを表示
- 「今後は表示しない」チェックボックスにより、Zustand persist（localStorage）でフラグを保存し2回目以降はスキップ

## 背景
ユーザーインタビューで「ひとりで」（個人メモ）と「みんなで」（公開投稿）の違いが伝わっていないケースが判明。新規ユーザーが投稿前に公開範囲を理解・確認できるようにする。

## 変更内容
### 新規ファイル
- `frontend/src/stores/publicityConfirmStore.ts` — Zustand persist ストア
- `frontend/src/components/shared/PublicityConfirmDialog/PublicityConfirmDialog.tsx` — ダイアログ本体
- `frontend/src/components/shared/PublicityConfirmDialog/PublicityConfirmDialog.module.css` — スタイル

### 変更ファイル
- `SocialPostsFeed.tsx` — FABの動作変更（href → onClick制御、ダイアログ表示判定）
- `ja.json` / `en.json` — `publicityConfirmDialog` セクション追加

## Test plan
- [x] `pnpm check` リントパス
- [x] `tsc --noEmit` 型チェックパス
- [x] `pnpm test` 全462テストパス
- [x] `next build` ビルド成功
- [x] ログイン → 「みんなで」投稿一覧 → FAB押下 → ダイアログ表示
- [x] ダイアログ外側タップで閉じないこと
- [x] アコーディオン開閉・公開範囲変更が動作すること
- [x] 「キャンセル」でダイアログ閉じ、遷移しないこと
- [x] 「確認しました」で `/social/posts/new` に遷移すること
- [x] 公開範囲変更後「確認しました」→ API更新後に遷移
- [x] 「今後は表示しない」+ 「確認しました」→ 次回FAB押下時にダイアログスキップ
- [x] 英語ロケールで翻訳が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)