### PR TITLE
fix: ツールチップUXとYouTube動画・添付ファイルの挙動改善

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
@@ -6,6 +6,7 @@ import {
   CaretUpIcon,
   ChartBar,
   CheckIcon,
+  InfoIcon,
   SortAscendingIcon,
   SortDescendingIcon,
 } from "@phosphor-icons/react";
@@ -20,6 +21,7 @@ import { Tutorial } from "@/components/features/tutorial/Tutorial";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import { FloatingActionButton } from "@/components/shared/FloatingActionButton/FloatingActionButton";
 import { Skeleton } from "@/components/shared/Skeleton";
+import { Tooltip } from "@/components/shared/Tooltip/Tooltip";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useTrainingPageFilters } from "@/lib/hooks/useTrainingPageFilters";
 import { useTrainingPageModals } from "@/lib/hooks/useTrainingPageModals";
@@ -147,7 +149,21 @@ export function PersonalPages() {
   return (
     <div className={styles.container}>
       <div className={styles.pageListHeader}>
-        <h2 className={styles.pageTitle}>{t("personalPages.pagesList")}</h2>
+        <div className={styles.pageTitleGroup}>
+          <h2 className={styles.pageTitle}>{t("personalPages.pagesList")}</h2>
+          <Tooltip
+            text={t("personalPages.pagesListTooltip")}
+            position="bottom"
+            align="left"
+            ariaLabel={t("personalPages.pagesListTooltip")}
+          >
+            <InfoIcon
+              size={16}
+              weight="regular"
+              className={styles.pageTitleInfoIcon}
+            />
+          </Tooltip>
+        </div>
         <div className={styles.otherPageLinks}>
           <Link
             href={`/${locale}/personal/stats`}

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/page.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/page.module.css
@@ -113,6 +113,16 @@
   color: var(--black);
 }
 
+.pageTitleGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pageTitleInfoIcon {
+  color: var(--text-light);
+}
+
 .sortDropdownContainer {
   position: relative;
 }

--- a/frontend/src/app/[locale]/(public)/social/profile/SocialProfile.module.css
+++ b/frontend/src/app/[locale]/(public)/social/profile/SocialProfile.module.css
@@ -35,7 +35,6 @@
 
 .statValueWithInfo [role="tooltip"] {
   max-width: min(200px, 80vw);
-  background-color: var(--primary-color);
 }
 
 .statLabel {

--- a/frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx
+++ b/frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx
@@ -307,12 +307,15 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
                 {profile.total_favorites ?? 0}
               </span>
             ) : (
-              <span className={styles.statValueWithInfo}>
+              <Tooltip
+                text={t("otherUserFavoritesHidden")}
+                position="bottom"
+                className={styles.statValueWithInfo}
+                ariaLabel={t("otherUserFavoritesHidden")}
+              >
                 ???
-                <Tooltip text={t("otherUserFavoritesHidden")} position="bottom">
-                  <InfoIcon size={14} weight="regular" />
-                </Tooltip>
-              </span>
+                <InfoIcon size={14} weight="regular" />
+              </Tooltip>
             )}
             <span className={styles.statLabel}>{t("totalFavorites")}</span>
           </div>

--- a/frontend/src/app/api/ogp/route.ts
+++ b/frontend/src/app/api/ogp/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSupabase } from "@/lib/supabase/server";
-
-// YouTube URL パターン
-const YOUTUBE_URL_PATTERNS = [
-  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/,
-  /(?:https?:\/\/)?youtu\.be\/([a-zA-Z0-9_-]{11})/,
-  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
-  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
-];
+import { extractYouTubeVideoId } from "@/lib/utils/youtube";
 
 interface YouTubeOEmbedResponse {
   title: string;
@@ -21,17 +14,6 @@ interface OgpResponse {
   thumbnail_url: string;
   video_id: string;
   author_name: string;
-}
-
-// YouTube URLからビデオIDを抽出
-function extractYouTubeVideoId(url: string): string | null {
-  for (const pattern of YOUTUBE_URL_PATTERNS) {
-    const match = url.match(pattern);
-    if (match?.[1]) {
-      return match[1];
-    }
-  }
-  return null;
 }
 
 // YouTube oEmbed APIからメタデータを取得

--- a/frontend/src/app/api/page-attachments/route.ts
+++ b/frontend/src/app/api/page-attachments/route.ts
@@ -18,6 +18,7 @@ const createAttachmentSchema = z.object({
   thumbnail_url: z.string().url().optional().nullable(),
   original_filename: z.string().optional().nullable(),
   file_size_bytes: z.number().optional().nullable(),
+  sort_order: z.number().int().min(0).optional(),
 });
 
 // 添付作成API
@@ -84,18 +85,23 @@ export async function POST(request: NextRequest) {
       attachmentUrl = generatePublicUrl(validatedData.file_key);
     }
 
-    // 現在の最大sort_orderを取得
-    const { data: existingAttachments } = await supabase
-      .from("PageAttachment")
-      .select("sort_order")
-      .eq("page_id", validatedData.page_id)
-      .order("sort_order", { ascending: false })
-      .limit(1);
+    // sort_order が明示指定されていればそれを使用、なければ現在の最大値+1 を採番
+    let nextSortOrder: number;
+    if (validatedData.sort_order !== undefined) {
+      nextSortOrder = validatedData.sort_order;
+    } else {
+      const { data: existingAttachments } = await supabase
+        .from("PageAttachment")
+        .select("sort_order")
+        .eq("page_id", validatedData.page_id)
+        .order("sort_order", { ascending: false })
+        .limit(1);
 
-    const nextSortOrder =
-      existingAttachments && existingAttachments.length > 0
-        ? (existingAttachments[0].sort_order ?? 0) + 1
-        : 0;
+      nextSortOrder =
+        existingAttachments && existingAttachments.length > 0
+          ? (existingAttachments[0].sort_order ?? 0) + 1
+          : 0;
+    }
 
     // 添付レコードを作成
     const { data: newAttachment, error: insertError } = await supabase

--- a/frontend/src/app/api/social-post-attachments/route.ts
+++ b/frontend/src/app/api/social-post-attachments/route.ts
@@ -17,6 +17,7 @@ const createAttachmentSchema = z.object({
   thumbnail_url: z.string().url().optional().nullable(),
   original_filename: z.string().optional().nullable(),
   file_size_bytes: z.number().optional().nullable(),
+  sort_order: z.number().int().min(0).optional(),
 });
 
 export async function POST(request: NextRequest) {
@@ -80,18 +81,23 @@ export async function POST(request: NextRequest) {
       attachmentUrl = generatePublicUrl(validatedData.file_key);
     }
 
-    // 現在の最大sort_orderを取得
-    const { data: existingAttachments } = await supabase
-      .from("SocialPostAttachment")
-      .select("sort_order")
-      .eq("post_id", validatedData.post_id)
-      .order("sort_order", { ascending: false })
-      .limit(1);
+    // sort_order が明示指定されていればそれを使用、なければ現在の最大値+1 を採番
+    let nextSortOrder: number;
+    if (validatedData.sort_order !== undefined) {
+      nextSortOrder = validatedData.sort_order;
+    } else {
+      const { data: existingAttachments } = await supabase
+        .from("SocialPostAttachment")
+        .select("sort_order")
+        .eq("post_id", validatedData.post_id)
+        .order("sort_order", { ascending: false })
+        .limit(1);
 
-    const nextSortOrder =
-      existingAttachments && existingAttachments.length > 0
-        ? (existingAttachments[0].sort_order ?? 0) + 1
-        : 0;
+      nextSortOrder =
+        existingAttachments && existingAttachments.length > 0
+          ? (existingAttachments[0].sort_order ?? 0) + 1
+          : 0;
+    }
 
     const { data: newAttachment, error: insertError } = await supabase
       .from("SocialPostAttachment")

--- a/frontend/src/components/features/personal/AttachmentUpload/AttachmentUpload.tsx
+++ b/frontend/src/components/features/personal/AttachmentUpload/AttachmentUpload.tsx
@@ -67,33 +67,19 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
     setUploadingFileName("");
   }, []);
 
-  // ファイル選択
-  const handleFileSelect = useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      if (!file) return;
-
-      // 件数上限チェック
-      if (attachments.length >= ATTACHMENT_MAX_COUNT) {
-        setError(t("pageModal.attachments.maxCountReached"));
-        if (fileInputRef.current) fileInputRef.current.value = "";
-        return;
-      }
-
-      // クライアントサイドでのサイズチェック
+  // 1ファイルのアップロード処理。cancel 時は Error("cancelled") を throw
+  const uploadOneFile = useCallback(
+    async (file: File, label: string) => {
       const isVideo = file.type.startsWith("video/");
       const maxSize = isVideo ? 300 * 1024 * 1024 : 5 * 1024 * 1024;
       if (file.size > maxSize) {
-        setError(
+        throw new Error(
           isVideo
             ? t("pageModal.attachments.videoFileTooLarge")
             : t("pageModal.attachments.imageFileTooLarge"),
         );
-        if (fileInputRef.current) fileInputRef.current.value = "";
-        return;
       }
 
-      // 画像の場合は圧縮
       let uploadFile: File = file;
       if (!isVideo && file.type.startsWith("image/")) {
         try {
@@ -101,114 +87,149 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
             maxWidth: 1920,
             maxHeight: 1920,
             quality: 0.85,
-            maxFileSize: 3 * 1024 * 1024, // 3MB
+            maxFileSize: 3 * 1024 * 1024,
           });
         } catch {
           // 圧縮失敗時は元ファイルをそのまま使用
         }
       }
 
+      setUploadProgress(0);
+      setUploadingFileName(`${label}${uploadFile.name}`);
+
+      const response = await fetch("/api/upload-url", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          filename: uploadFile.name,
+          contentType: uploadFile.type,
+          fileSize: uploadFile.size,
+          uploadType,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData.error || t("pageModal.attachments.uploadFailed"),
+        );
+      }
+
+      const { uploadUrl, fileKey }: UploadResponse = await response.json();
+
+      await new Promise<void>((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhrRef.current = xhr;
+
+        xhr.upload.addEventListener("progress", (e) => {
+          if (e.lengthComputable) {
+            setUploadProgress(Math.round((e.loaded / e.total) * 100));
+          }
+        });
+
+        xhr.addEventListener("load", () => {
+          xhrRef.current = null;
+          if (xhr.status === 200) {
+            resolve();
+          } else {
+            reject(
+              new Error(
+                `${t("pageModal.attachments.uploadFailed")} (${xhr.status})`,
+              ),
+            );
+          }
+        });
+
+        xhr.addEventListener("error", () => {
+          xhrRef.current = null;
+          reject(new Error(t("pageModal.attachments.uploadFailed")));
+        });
+
+        xhr.addEventListener("abort", () => {
+          xhrRef.current = null;
+          reject(new Error("cancelled"));
+        });
+
+        xhr.open("PUT", uploadUrl);
+        xhr.setRequestHeader("Content-Type", uploadFile.type);
+        xhr.send(uploadFile);
+      });
+
+      const cloudFrontDomain = process.env.NEXT_PUBLIC_CLOUDFRONT_DOMAIN || "";
+
+      const newAttachment: AttachmentData = {
+        id: generateTempId(),
+        type: isVideo ? "video" : "image",
+        url: `https://${cloudFrontDomain}/${fileKey}`,
+        original_filename: uploadFile.name,
+        file_size_bytes: uploadFile.size,
+      };
+
+      onAttachmentAdd({
+        ...newAttachment,
+        ...({ _fileKey: fileKey } as Record<string, string>),
+      });
+    },
+    [onAttachmentAdd, t, uploadType],
+  );
+
+  // ファイル選択（複数可）。選択順に逐次アップロードして順序を保持
+  const handleFileSelect = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const selected = Array.from(event.target.files ?? []);
+      if (selected.length === 0) return;
+
+      const clearInput = () => {
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      };
+
+      const available = ATTACHMENT_MAX_COUNT - attachments.length;
+      if (available <= 0) {
+        setError(t("pageModal.attachments.maxCountReached"));
+        clearInput();
+        return;
+      }
+
+      const filesToUpload = selected.slice(0, available);
+      const skipped = selected.length - filesToUpload.length;
+
       setError(null);
       setIsUploading(true);
-      setUploadProgress(0);
-      setUploadingFileName(uploadFile.name);
 
+      let lastError: string | null = null;
       try {
-        // ステップ1: 署名付きURL取得
-        const response = await fetch("/api/upload-url", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            filename: uploadFile.name,
-            contentType: uploadFile.type,
-            fileSize: uploadFile.size,
-            uploadType,
-          }),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(
-            errorData.error || t("pageModal.attachments.uploadFailed"),
-          );
+        for (let i = 0; i < filesToUpload.length; i++) {
+          const file = filesToUpload[i];
+          const label =
+            filesToUpload.length > 1
+              ? `(${i + 1}/${filesToUpload.length}) `
+              : "";
+          try {
+            await uploadOneFile(file, label);
+          } catch (err) {
+            if (err instanceof Error && err.message === "cancelled") {
+              break;
+            }
+            lastError =
+              err instanceof Error
+                ? err.message
+                : t("pageModal.attachments.uploadFailed");
+          }
         }
-
-        const { uploadUrl, fileKey }: UploadResponse = await response.json();
-
-        // ステップ2: S3にアップロード
-        await new Promise<void>((resolve, reject) => {
-          const xhr = new XMLHttpRequest();
-          xhrRef.current = xhr;
-
-          xhr.upload.addEventListener("progress", (e) => {
-            if (e.lengthComputable) {
-              setUploadProgress(Math.round((e.loaded / e.total) * 100));
-            }
-          });
-
-          xhr.addEventListener("load", () => {
-            xhrRef.current = null;
-            if (xhr.status === 200) {
-              resolve();
-            } else {
-              reject(
-                new Error(
-                  `${t("pageModal.attachments.uploadFailed")} (${xhr.status})`,
-                ),
-              );
-            }
-          });
-
-          xhr.addEventListener("error", () => {
-            xhrRef.current = null;
-            reject(new Error(t("pageModal.attachments.uploadFailed")));
-          });
-
-          xhr.addEventListener("abort", () => {
-            xhrRef.current = null;
-            reject(new Error("cancelled"));
-          });
-
-          xhr.open("PUT", uploadUrl);
-          xhr.setRequestHeader("Content-Type", uploadFile.type);
-          xhr.send(uploadFile);
-        });
-
-        // ステップ3: 添付データを追加
-        const isVideo = uploadFile.type.startsWith("video/");
-        const cloudFrontDomain =
-          process.env.NEXT_PUBLIC_CLOUDFRONT_DOMAIN || "";
-
-        const newAttachment: AttachmentData = {
-          id: generateTempId(),
-          type: isVideo ? "video" : "image",
-          url: `https://${cloudFrontDomain}/${fileKey}`,
-          original_filename: uploadFile.name,
-          file_size_bytes: uploadFile.size,
-        };
-
-        onAttachmentAdd({
-          ...newAttachment,
-          // file_key を添付データに含める（POST /api/page-attachments 用）
-          ...({ _fileKey: fileKey } as Record<string, string>),
-        });
-      } catch (err) {
-        if (err instanceof Error && err.message === "cancelled") return;
-        setError(
-          err instanceof Error
-            ? err.message
-            : t("pageModal.attachments.uploadFailed"),
-        );
       } finally {
         setIsUploading(false);
         setUploadProgress(0);
         setUploadingFileName("");
-        if (fileInputRef.current) {
-          fileInputRef.current.value = "";
-        }
+        clearInput();
+      }
+
+      if (lastError) {
+        setError(lastError);
+      } else if (skipped > 0) {
+        setError(t("pageModal.attachments.maxCountReached"));
       }
     },
-    [attachments.length, onAttachmentAdd, t, uploadType],
+    [attachments.length, t, uploadOneFile],
   );
 
   // YouTube URL入力のデバウンスチェック
@@ -293,6 +314,7 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
       <input
         ref={fileInputRef}
         type="file"
+        multiple
         accept="image/jpeg,image/jpg,image/png,image/webp,video/mp4,video/quicktime,video/webm"
         onChange={handleFileSelect}
         disabled={disabled || isUploading || isMaxReached}

--- a/frontend/src/components/features/personal/MediaPlayer/MediaPlayer.tsx
+++ b/frontend/src/components/features/personal/MediaPlayer/MediaPlayer.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { type CSSProperties, type FC, useCallback, useState } from "react";
+import { buildYouTubeEmbedSrc } from "@/lib/utils/youtube";
 import styles from "./MediaPlayer.module.css";
 
 interface MediaPlayerProps {
@@ -11,24 +12,6 @@ interface MediaPlayerProps {
   alt?: string;
   fillParent?: boolean;
   onImageLoad?: (naturalWidth: number, naturalHeight: number) => void;
-}
-
-// YouTube URLからビデオIDを抽出
-function extractYouTubeVideoId(url: string): string | null {
-  const patterns = [
-    /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/,
-    /(?:https?:\/\/)?youtu\.be\/([a-zA-Z0-9_-]{11})/,
-    /(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
-    /(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
-  ];
-
-  for (const pattern of patterns) {
-    const match = url.match(pattern);
-    if (match?.[1]) {
-      return match[1];
-    }
-  }
-  return null;
 }
 
 export const MediaPlayer: FC<MediaPlayerProps> = ({
@@ -64,9 +47,9 @@ export const MediaPlayer: FC<MediaPlayerProps> = ({
   const containerClass = `${styles.container} ${fillParent ? styles.fillParent : ""} ${isLandscape ? styles.containerLandscape : ""}`;
   const aspectClass = `${styles.aspectRatio} ${fillParent ? styles.fillParentAspect : ""}`;
   if (type === "youtube") {
-    const videoId = extractYouTubeVideoId(url);
+    const embedSrc = buildYouTubeEmbedSrc(url);
 
-    if (!videoId) {
+    if (!embedSrc) {
       return (
         <div className={containerClass}>
           <div className={aspectClass}>
@@ -81,7 +64,7 @@ export const MediaPlayer: FC<MediaPlayerProps> = ({
         <div className={aspectClass}>
           <iframe
             className={styles.iframe}
-            src={`https://www.youtube-nocookie.com/embed/${videoId}`}
+            src={embedSrc}
             title={alt}
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen

--- a/frontend/src/components/shared/Tooltip/Tooltip.module.css
+++ b/frontend/src/components/shared/Tooltip/Tooltip.module.css
@@ -9,7 +9,7 @@
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  background-color: var(--black);
+  background-color: var(--primary-color);
   color: var(--white);
   font-size: var(--font-size-xs, 12px);
   padding: 6px 12px;

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -9,6 +9,8 @@ interface TooltipProps {
   children: ReactNode;
   position?: "top" | "bottom";
   align?: "center" | "left" | "right";
+  className?: string;
+  ariaLabel?: string;
 }
 
 export const Tooltip: FC<TooltipProps> = ({
@@ -16,6 +18,8 @@ export const Tooltip: FC<TooltipProps> = ({
   children,
   position = "top",
   align = "center",
+  className,
+  ariaLabel,
 }) => {
   const [visible, setVisible] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -41,9 +45,10 @@ export const Tooltip: FC<TooltipProps> = ({
   return (
     // biome-ignore lint/a11y/useSemanticElements: Using span with role="button" for inline tooltip trigger that needs to wrap arbitrary children
     <span
-      className={styles.wrapper}
+      className={`${styles.wrapper}${className ? ` ${className}` : ""}`}
       role="button"
       tabIndex={0}
+      aria-label={ariaLabel}
       onMouseEnter={show}
       onMouseLeave={hide}
       onFocus={show}

--- a/frontend/src/lib/hooks/useAttachmentManagement.ts
+++ b/frontend/src/lib/hooks/useAttachmentManagement.ts
@@ -57,14 +57,17 @@ export function useAttachmentManagement(
   const saveNewAttachments = useCallback(
     async (entityId: string) => {
       const current = attachmentsRef.current;
-      const newAttachments = current.filter((a) => a.id.startsWith("temp-"));
-      if (newAttachments.length === 0) return;
+      // 全体配列の index をそのまま sort_order として保持し、新規分のみ抽出する
+      const tasks = current
+        .map((att, idx) => ({ att, sortOrder: idx }))
+        .filter(({ att }) => att.id.startsWith("temp-"));
+      if (tasks.length === 0) return;
 
       const idField = entityType === "page" ? "page_id" : "post_id";
       const endpoint = getDeleteEndpoint(entityType);
 
       await Promise.allSettled(
-        newAttachments.map((attachment, i) => {
+        tasks.map(({ att: attachment, sortOrder }) => {
           if (entityType === "page") {
             const payload: Record<string, unknown> = {
               [idField]: entityId,
@@ -72,6 +75,7 @@ export function useAttachmentManagement(
               original_filename: attachment.original_filename ?? null,
               file_size_bytes: attachment.file_size_bytes ?? null,
               thumbnail_url: attachment.thumbnail_url ?? null,
+              sort_order: sortOrder,
             };
             if (attachment.type === "youtube") {
               payload.url = attachment.url;
@@ -91,7 +95,7 @@ export function useAttachmentManagement(
               url: attachment.type === "youtube" ? attachment.url : undefined,
               original_filename: attachment.original_filename ?? null,
               file_size_bytes: attachment.file_size_bytes ?? null,
-              sort_order: i,
+              sort_order: sortOrder,
             }),
           });
         }),

--- a/frontend/src/lib/utils/youtube.ts
+++ b/frontend/src/lib/utils/youtube.ts
@@ -1,0 +1,64 @@
+const YOUTUBE_URL_PATTERNS = [
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/,
+  /(?:https?:\/\/)?youtu\.be\/([a-zA-Z0-9_-]{11})/,
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+];
+
+export function extractYouTubeVideoId(url: string): string | null {
+  for (const pattern of YOUTUBE_URL_PATTERNS) {
+    const match = url.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+function parseTimeToSeconds(value: string): number | null {
+  if (/^\d+$/.test(value)) {
+    const n = Number.parseInt(value, 10);
+    return Number.isFinite(n) ? n : null;
+  }
+  const hms = value.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (!hms || !(hms[1] || hms[2] || hms[3])) return null;
+  const h = Number.parseInt(hms[1] ?? "0", 10);
+  const m = Number.parseInt(hms[2] ?? "0", 10);
+  const s = Number.parseInt(hms[3] ?? "0", 10);
+  return h * 3600 + m * 60 + s;
+}
+
+export function extractYouTubeStartSeconds(url: string): number | null {
+  let rawValue: string | null = null;
+  try {
+    const normalized = url.startsWith("http") ? url : `https://${url}`;
+    const parsed = new URL(normalized);
+    rawValue =
+      parsed.searchParams.get("t") ?? parsed.searchParams.get("start") ?? null;
+  } catch {
+    const match = url.match(/[?&](?:t|start)=([^&#]+)/);
+    rawValue = match?.[1] ?? null;
+  }
+
+  if (!rawValue) return null;
+
+  const seconds = parseTimeToSeconds(rawValue);
+  return seconds !== null && seconds >= 0 ? seconds : null;
+}
+
+export function parseYouTubeUrl(
+  url: string,
+): { videoId: string; startSeconds: number | null } | null {
+  const videoId = extractYouTubeVideoId(url);
+  if (!videoId) return null;
+  return { videoId, startSeconds: extractYouTubeStartSeconds(url) };
+}
+
+export function buildYouTubeEmbedSrc(url: string): string | null {
+  const parsed = parseYouTubeUrl(url);
+  if (!parsed) return null;
+  const base = `https://www.youtube-nocookie.com/embed/${parsed.videoId}`;
+  return parsed.startSeconds !== null
+    ? `${base}?start=${parsed.startSeconds}`
+    : base;
+}

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -500,6 +500,7 @@
     "pageCount": "Total pages created so far:",
     "pageCountSuffix": "pages",
     "pagesList": "Pages List",
+    "pagesListTooltip": "Pages are personal training memos that only you can view and manage. They will never be shared publicly.",
     "sortNewest": "Newest",
     "sortOldest": "Oldest",
     "stats": "Stats",

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -502,6 +502,7 @@
     "pageCount": "これまでに作成したページ数は",
     "pageCountSuffix": "ページです",
     "pagesList": "ページ一覧",
+    "pagesListTooltip": "ページはあなた1人で閲覧・管理する稽古記録用のメモです。勝手に公開されることはありません。",
     "sortNewest": "新しい順",
     "sortOldest": "古い順",
     "stats": "統計データ",


### PR DESCRIPTION
## Summary

### ツールチップ関連
- プロフィール画面で他ユーザーのお気に入り数 `???` を閲覧する際、info アイコンだけでなく `???` 要素全体をタップ領域としてツールチップを表示するよう改善（タップ領域が小さすぎて押しにくかった問題の解消）。`Tooltip` コンポーネントに `className` / `ariaLabel` prop を追加。
- `/personal/pages/` のタイトル「ページ一覧」右隣に info アイコンを新規追加し、ページがユーザー本人のみの稽古記録メモである旨のツールチップを表示。翻訳キー `personalPages.pagesListTooltip` を ja/en に追加。
- 既存のツールチップ文言は全て翻訳キー化済みであることを確認済み。

### YouTube 開始位置対応
- YouTube URL の開始位置クエリ（`?t=227`, `?t=3m47s`, `?t=1h2m3s`, `&start=227` 等）がプレビュー/一覧/詳細のいずれにも反映されず常に 0:00 から再生されていた問題を修正。共通ユーティリティ `lib/utils/youtube.ts` を導入し、embed URL に `?start=N` を付加。

### 添付ファイル複数選択時の順序保持
- 稽古記録ページ・投稿の作成画面で画像を複数添付した際、プレビュー・保存後の順序が担保されていなかった問題を修正。`<input type=file>` を `multiple` 対応にして選択順で逐次アップロード、`useAttachmentManagement` から全体 index を `sort_order` として明示送信、API 側は zod schema に `sort_order` を追加してそれを採用するよう変更（MAX+1 自動採番による race condition を解消）。

DB マイグレーションは不要（既存スキーマで対応可能）。

## Test plan

### ツールチップ
- [x] 他ユーザーのプロフィール画面で `???` 全体をタップするとツールチップが出る
- [x] `/personal/pages/` のタイトル横の info アイコンをタップするとツールチップが出る
- [x] 英語ロケールでもツールチップ文言が正しく表示される

### YouTube
- [x] `https://youtu.be/-OPtYIGUChg?t=227` 添付で 3:47 から再生される（プレビュー/一覧/詳細）
- [x] `?t=227s` / `?t=3m47s` / `?t=1h2m3s` / `&start=227` の各形式でも反映される
- [x] 開始位置なし URL が 0:00 から再生される（リグレッション）
- [x] 不正 URL で「動画を読み込めません」フォールバックが表示される
- [x] `/social/posts/new` でも同様に反映される

### 添付順序
- [x] `/personal/pages/new` でファイル選択ダイアログから画像を複数枚選択 → プレビューが選択順に並ぶ
- [x] 保存 → 一覧・詳細でも選択順が維持される（複数回試行しても順序が崩れない）
- [x] 画像・YouTube を混在添付した場合でも順序が維持される
- [x] `/social/posts/new` でも複数選択 → 保存 → 順序一致を確認
- [x] 編集画面で既存添付の後ろに新規追加した場合、既存の後ろに選択順で並ぶ
- [x] `ATTACHMENT_MAX_COUNT` 超過時は上限内まで処理され適切なエラーが出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)