### PR TITLE
feat: ツールチップの永続表示化とページ一覧アイコンの変更

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
@@ -6,7 +6,7 @@ import {
   CaretUpIcon,
   ChartBar,
   CheckIcon,
-  InfoIcon,
+  QuestionIcon,
   SortAscendingIcon,
   SortDescendingIcon,
 } from "@phosphor-icons/react";
@@ -157,7 +157,7 @@ export function PersonalPages() {
             align="left"
             ariaLabel={t("personalPages.pagesListTooltip")}
           >
-            <InfoIcon
+            <QuestionIcon
               size={16}
               weight="regular"
               className={styles.pageTitleInfoIcon}

--- a/frontend/src/components/shared/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/shared/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FC, ReactNode } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import styles from "./Tooltip.module.css";
 
 interface TooltipProps {
@@ -22,39 +22,62 @@ export const Tooltip: FC<TooltipProps> = ({
   ariaLabel,
 }) => {
   const [visible, setVisible] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
 
-  const show = useCallback(() => setVisible(true), []);
-  const hide = useCallback(() => setVisible(false), []);
-
-  const handleTouchStart = useCallback(() => {
-    timerRef.current = setTimeout(() => {
-      setVisible(true);
-    }, 500);
+  const handlePointerEnter = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === "mouse") setVisible(true);
   }, []);
 
-  const handleTouchEnd = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
+  const handlePointerLeave = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === "mouse") setVisible(false);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    setVisible((v) => !v);
+  }, []);
+
+  const handleFocus = useCallback(() => setVisible(true), []);
+  const handleBlur = useCallback(() => setVisible(false), []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setVisible((v) => !v);
+    } else if (e.key === "Escape") {
+      setVisible(false);
     }
-    // 表示後は少し遅延して閉じる
-    setTimeout(() => setVisible(false), 2000);
   }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    const onDocPointerDown = (e: PointerEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setVisible(false);
+      }
+    };
+    document.addEventListener("pointerdown", onDocPointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", onDocPointerDown);
+    };
+  }, [visible]);
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: Using span with role="button" for inline tooltip trigger that needs to wrap arbitrary children
     <span
+      ref={wrapperRef}
       className={`${styles.wrapper}${className ? ` ${className}` : ""}`}
       role="button"
       tabIndex={0}
       aria-label={ariaLabel}
-      onMouseEnter={show}
-      onMouseLeave={hide}
-      onFocus={show}
-      onBlur={hide}
-      onTouchStart={handleTouchStart}
-      onTouchEnd={handleTouchEnd}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
     >
       {children}
       {visible && (


### PR DESCRIPTION
## Summary
- 共通 `Tooltip` コンポーネントが一定時間経過で勝手に非表示になる挙動を廃止。タップで表示 → 外側タップ / ツールチップ自身タップ / トリガー再タップ / 画面リロードまで表示が維持されるよう変更（`document` の `pointerdown` リスナーで外側タップを検知、内側要素は `onClick` の伝播でトグル）。
- タッチデバイスでの `mouseenter` 誤発火で一瞬表示されてすぐ閉じる事故を防ぐため、ポインタ系ハンドラは `e.pointerType === "mouse"` で絞り込み。デスクトップのホバー挙動は維持。
- キーボード操作（`Enter` / `Space` でトグル、`Esc` で閉じる、`focus` / `blur` 連動）にも対応。
- `/personal/pages/` タイトル横のアイコンを `InfoIcon`（i）から `QuestionIcon`（?）に変更し、ヘルプ的な意図を明示。他のページで使用中の `InfoIcon` は据え置き。

## Test plan
- [x] SPで `/personal/pages/` を開き、タイトル右の ? をタップ → ツールチップが表示されて数秒経っても消えない
- [x] 表示中にツールチップの外をタップ → 非表示
- [x] トリガー（? アイコン）をもう一度タップ → 非表示（トグル）
- [x] ツールチップのテキスト自体をタップ → 非表示
- [x] プロフィール画面の「???」要素でも同じ挙動
- [x] 画面リロードで表示状態がリセットされる
- [x] PC ブラウザでマウスホバー → 表示、ホバーを外す → 非表示
- [x] キーボードで Tab → 表示、Enter / Space でトグル、Esc で閉じる
- [x] `/personal/pages/` タイトル横のアイコンが ? になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)