### PR TITLE
feat: 稽古記録ページ「他のユーザーに公開」のプレミアム訴求文言を差し替え

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/PageDetail.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/PageDetail.tsx
@@ -310,6 +310,7 @@ export function PageDetail() {
       <PremiumUpgradeModal
         isOpen={showPremiumModal}
         onClose={() => setShowPremiumModal(false)}
+        translationKey="premiumModalPublishPage"
       />
     </div>
   );

--- a/frontend/src/components/shared/PremiumUpgradeModal/PremiumUpgradeModal.tsx
+++ b/frontend/src/components/shared/PremiumUpgradeModal/PremiumUpgradeModal.tsx
@@ -39,6 +39,7 @@ export function PremiumUpgradeModal({
     premiumModalCalendar: "calendar",
     premiumModalStats: "stats",
     premiumModalDailyLimit: "daily_limit",
+    premiumModalPublishPage: "publish_page",
   };
   const context = CONTEXT_MAP[translationKey] ?? translationKey;
 

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -355,6 +355,15 @@
     "processing": "Processing...",
     "close": "Just keep recording"
   },
+  "premiumModalPublishPage": {
+    "badge": "PREMIUM",
+    "title": "Share your training\nwith the community in one tap",
+    "description": "Publish your solo training records to the community, just as they are, with a single tap.",
+    "upgradeMain": "Share with everyone",
+    "upgradeSub": "¥380 / month",
+    "processing": "Processing...",
+    "close": "Keep training records solo"
+  },
   "premiumModalDailyLimit": {
     "badge": "PREMIUM",
     "title": "You've reached today's\npost/reply limit",

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -355,6 +355,15 @@
     "processing": "処理中...",
     "close": "記録だけ続ける"
   },
+  "premiumModalPublishPage": {
+    "badge": "PREMIUM",
+    "title": "たったの1タップで、\n稽古の学びをみんなに公開",
+    "description": "ひとりでコツコツ積み重ねた稽古記録を、そのままの形でカンタンに公開・投稿することができます。",
+    "upgradeMain": "みんなに学びを共有する",
+    "upgradeSub": "月額 ¥380",
+    "processing": "処理中...",
+    "close": "ひとりで稽古記録を続ける"
+  },
   "premiumModalDailyLimit": {
     "badge": "PREMIUM",
     "title": "本日の投稿・返信数の\n上限に達しました",


### PR DESCRIPTION
## Summary
- 「ひとりで」の稽古記録ページ詳細画面で「他のユーザーに公開」トグルを Free ユーザーが押下したときに表示される \`PremiumUpgradeModal\` の文言を、公開機能に即した内容に差し替え。
- 新規翻訳キー \`premiumModalPublishPage\` を ja/en に追加:
  - title: 「たったの1タップで、稽古の学びをみんなに公開」
  - description: 「ひとりでコツコツ積み重ねた稽古記録を、そのままの形でカンタンに公開・投稿することができます。」
  - upgradeMain: 「みんなに学びを共有する」
  - close: 「ひとりで稽古記録を続ける」
- \`PageDetail.tsx\` から \`translationKey=\"premiumModalPublishPage\"\` を明示指定。
- \`PremiumUpgradeModal.tsx\` の \`CONTEXT_MAP\` に \`publish_page\` を追加し、Umami の \`premium_modal_upgrade\` / \`premium_modal_dismiss\` イベントで専用コンテキストとして計測できるように。
- デフォルトの \`premiumModal\` namespace は将来の用途のために残存。

## Test plan
- [x] Free ユーザーで \`/personal/pages/{id}\` を開き「他のユーザーに公開」をONに → 新文言のモーダルが表示される
- [x] 英語ロケール(\`/en/...\`)でも英訳が表示される
- [x] 他の呼び出し箇所(stats, calendar, social feed/detail, search, push notification)の文言が変わっていない(リグレッション)
- [x] モーダル内の「みんなに学びを共有する」タップで \`/settings/subscription\` に遷移する
- [x] 「ひとりで稽古記録を続ける」タップでモーダルが閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)