### PR TITLE
feat: ネイティブアプリ版リリース準備に伴う Web 側調整（Phase 3.5）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ logs/
 
 # Migrations
 database/migrations/
+.vercel

--- a/frontend/src/app/[locale]/(authenticated)/settings/subscription/SubscriptionSetting.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/settings/subscription/SubscriptionSetting.tsx
@@ -12,7 +12,9 @@ import { SubscriptionLayout } from "./SubscriptionLayout";
 declare global {
   interface Window {
     __AIKINOTE_NATIVE_APP__?: boolean;
-    showNativePaywall?: () => Promise<{ success: boolean; isPremium: boolean }>;
+    showNativePaywall?: (options?: {
+      planType?: "monthly" | "yearly";
+    }) => Promise<{ success: boolean; isPremium: boolean }>;
     showNativeCustomerCenter?: () => void;
   }
 }
@@ -112,13 +114,15 @@ export function SubscriptionSetting({ locale }: SubscriptionSettingProps) {
 
   const handleNativeUpgrade = useCallback(async () => {
     if (window.showNativePaywall) {
-      const result = await window.showNativePaywall();
+      const result = await window.showNativePaywall({
+        planType: selectedPeriod,
+      });
       if (result.success) {
         refetch();
         router.push("/settings/subscription?success=1");
       }
     }
-  }, [refetch, router]);
+  }, [refetch, router, selectedPeriod]);
 
   const handleManageSubscription = useCallback(async () => {
     if (isNativeApp && window.showNativeCustomerCenter) {

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearch.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearch.tsx
@@ -508,7 +508,7 @@ export function SocialSearch() {
   );
 
   return (
-    <SocialLayout>
+    <SocialLayout showTabNavigation={false}>
       <div className={styles.stickyTop}>
         <SocialHeader
           onBack={handleBack}

--- a/frontend/src/app/[locale]/(public)/login/Login.tsx
+++ b/frontend/src/app/[locale]/(public)/login/Login.tsx
@@ -57,6 +57,16 @@ export function Login({ locale, onSuccess }: LoginProps) {
       onSuccess?.();
     } catch (err) {
       console.error("Sign in error:", err);
+      const message = err instanceof Error ? err.message : "";
+      if (message.includes("メールアドレスまたはパスワード")) {
+        // トースト表示 + プリフィルは /signup 側で ?from=login を検出して実施する
+        const emailParam = encodeURIComponent(data.email);
+        const localePrefix =
+          resolvedLocale === "ja" ? "" : `/${resolvedLocale}`;
+        window.location.replace(
+          `${localePrefix}/signup?from=login&email=${emailParam}`,
+        );
+      }
     }
   };
 

--- a/frontend/src/app/[locale]/(public)/signup/SignUp.tsx
+++ b/frontend/src/app/[locale]/(public)/signup/SignUp.tsx
@@ -3,6 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Check } from "@phosphor-icons/react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useId, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -70,6 +71,19 @@ export function SignUp({ locale, onSuccess }: SignUpProps) {
     }
   }, [showEmailForm, emailPasswordForm]);
 
+  // /login から「アカウント未作成」としてリダイレクトされた場合、メール欄を自動展開・プリフィルし案内を表示
+  const searchParams = useSearchParams();
+  const [redirectedFromLogin, setRedirectedFromLogin] = useState(false);
+  useEffect(() => {
+    if (searchParams.get("from") !== "login") return;
+    const email = searchParams.get("email");
+    if (email) {
+      emailPasswordForm.setValue("email", email, { shouldValidate: true });
+    }
+    setShowEmailForm(true);
+    setRedirectedFromLogin(true);
+  }, [searchParams, emailPasswordForm]);
+
   const handleEmailPasswordSubmit = async (data: EmailPasswordFormData) => {
     setEmailPasswordData(data);
     usernameForm.setValue("username", generateUsernameFromEmail(data.email));
@@ -127,6 +141,24 @@ export function SignUp({ locale, onSuccess }: SignUpProps) {
     <div className={styles.container}>
       <h1 className={styles.title}>{t("auth.signup")}</h1>
       <p className={styles.subtitle}>{t("auth.signupSubtitle")}</p>
+
+      {/* /login から遷移してきた場合の案内 */}
+      {redirectedFromLogin && (
+        <output
+          style={{
+            display: "block",
+            padding: "12px 16px",
+            marginBottom: 16,
+            borderRadius: 8,
+            background: "var(--background-light)",
+            color: "var(--black)",
+            fontSize: 14,
+            lineHeight: 1.5,
+          }}
+        >
+          アカウントが見つかりませんでした。こちらから新規登録をお願いします。
+        </output>
+      )}
 
       {/* 利用規約・プライバシーポリシー同意カード */}
       <div

--- a/frontend/src/components/features/social/SocialFeedHeader/SocialFeedHeader.tsx
+++ b/frontend/src/components/features/social/SocialFeedHeader/SocialFeedHeader.tsx
@@ -9,7 +9,7 @@ import {
 } from "@phosphor-icons/react";
 import { usePathname } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import type { FC } from "react";
+import { type FC, useEffect } from "react";
 import { SocialHeader } from "@/components/shared/layouts/SocialLayout";
 import { ProfileImage } from "@/components/shared/ProfileImage/ProfileImage";
 import { useAuth } from "@/lib/hooks/useAuth";
@@ -30,6 +30,22 @@ export const SocialFeedHeader: FC<SocialFeedHeaderProps> = ({
   const pathname = usePathname();
   const { user } = useAuth();
   const unreadCount = useUnreadNotificationCount(user?.id);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const w = window as unknown as {
+      __AIKINOTE_NATIVE_APP__?: boolean;
+      ReactNativeWebView?: { postMessage: (msg: string) => void };
+    };
+    if (w.__AIKINOTE_NATIVE_APP__ && w.ReactNativeWebView) {
+      w.ReactNativeWebView.postMessage(
+        JSON.stringify({
+          type: "UNREAD_NOTIFICATION_COUNT",
+          payload: { count: unreadCount },
+        }),
+      );
+    }
+  }, [unreadCount]);
 
   const getActiveTab = () => {
     const localePrefix = `/${locale}`;

--- a/frontend/src/components/features/tutorial/Tutorial.tsx
+++ b/frontend/src/components/features/tutorial/Tutorial.tsx
@@ -40,6 +40,26 @@ export function Tutorial() {
     setMounted(true);
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const w = window as unknown as {
+      __AIKINOTE_NATIVE_APP__?: boolean;
+      ReactNativeWebView?: { postMessage: (msg: string) => void };
+    };
+    const send = (active: boolean) => {
+      if (w.__AIKINOTE_NATIVE_APP__ && w.ReactNativeWebView) {
+        w.ReactNativeWebView.postMessage(
+          JSON.stringify({
+            type: "TUTORIAL_STATE",
+            payload: { active },
+          }),
+        );
+      }
+    };
+    send(true);
+    return () => send(false);
+  }, []);
+
   const SKIP_EVENT_NAMES = [
     "tutorial_step1_skip",
     "tutorial_step2_skip",

--- a/frontend/src/components/shared/FloatingActionButton/FloatingActionButton.module.css
+++ b/frontend/src/components/shared/FloatingActionButton/FloatingActionButton.module.css
@@ -1,6 +1,6 @@
 .fab {
   position: fixed;
-  bottom: 100px;
+  bottom: var(--fab-bottom);
   right: 14px;
   width: 100px;
   height: 100px;
@@ -24,7 +24,7 @@
 }
 
 [data-font-size="large"] .fab {
-  bottom: 125px;
+  bottom: var(--fab-bottom-large);
 }
 
 .icon {

--- a/frontend/src/styles/variables.css
+++ b/frontend/src/styles/variables.css
@@ -68,6 +68,14 @@
   --font-size-large: 20px;
   --current-font-size: var(--font-size-medium);
 
+  /* ── FAB 下端位置 ── */
+  /* TabNavigation（約 82px）の上に FAB を浮かせるための値。
+     ネイティブアプリのように TabNavigation を非表示にする環境では、
+     `:root` レベルでこの変数を小さな値（例: 18px）に上書きすることで
+     FAB の下方スペースを調整できる。 */
+  --fab-bottom: 100px; /* SP: TabNavigation 分 + 余白 */
+  --fab-bottom-large: 125px; /* SP large font */
+
   /* ── z-index レイヤー管理 ── */
   /* グローバルな重なり順：値が大きいほど前面 */
   /* 10の倍数で間隔を確保 → ローカルスタッキングコンテキストとの衝突を防止 */


### PR DESCRIPTION
## Summary

ネイティブアプリ版（aikinote-native-app）の Phase 3.5 リリース前改善に合わせた Web 版の変更です。ネイティブアプリ側のリポジトリでは同等の変更（`feat: Phase 3.5 リリース前改善タスク群を実装` / commit `6413fca`）を main にマージ済み。

## 主な変更

### T1: 初回チュートリアル表示中のネイティブヘッダー/タブバー非表示
- `Tutorial.tsx` mount/unmount で `TUTORIAL_STATE { active: boolean }` をネイティブアプリに postMessage
- ネイティブアプリ側はこの値を受け取り、ネイティブヘッダー・タブバーを描画しない

### T2: ログイン失敗時の /signup リダイレクト
- `Login.tsx` でアカウント未作成エラー時 `window.location.replace('/signup?from=login&email=...')` で遷移
- `SignUp.tsx` で `?from=login` を検知してメール欄のプリフィルとメールフォーム自動展開、インライン案内バナー表示

### T3: 未読通知数のネイティブ側同期
- `SocialFeedHeader.tsx` の `useUnreadNotificationCount` の結果を `UNREAD_NOTIFICATION_COUNT` として postMessage
- ネイティブの SocialFeedHeader のベルアイコンバッジ表示で使用

### T4: RevenueCat Paywall スキップ対応
- `SubscriptionSetting.tsx` の `handleNativeUpgrade` で `INITIATE_IAP` の payload に `planType: "monthly" | "yearly"` を含める
- ネイティブ側では planType を元に `Purchases.purchasePackage` を直接呼び出し、Paywall UI ではなく OS 標準の購入ダイアログが出る

### タブバー表示ルール統一
- `/social/posts/search` を `<SocialLayout showTabNavigation={false}>` に変更して検索結果領域を広く確保

### FAB の bottom 位置を CSS 変数化
- `variables.css` に `--fab-bottom` / `--fab-bottom-large` を追加
- `FloatingActionButton.module.css` で `bottom: var(--fab-bottom)` を参照
- ネイティブアプリ側で CSS 注入によりこの変数を上書きし、TabNavigation 分の余白を詰めて自然な位置に

## Test plan

- [ ] `/login` で存在しないメールを入力 → `/signup` にリダイレクト、メールがプリフィルされ、バナーが表示される
- [ ] `/personal/pages` 初回アクセスでチュートリアルが表示される（ネイティブアプリでは上部/下部ヘッダーが消える）
- [ ] `/social/posts` で BellIcon タップ → `/social/notifications` に遷移、未読あれば赤バッジ表示
- [ ] `/settings/subscription` で月額/年額トグル → 両方とも選択したプランが購入ダイアログに出る（ネイティブアプリ）
- [ ] `/social/posts/search` で下部タブバーが出ない（SP）
- [ ] `/personal/pages` と `/social/posts` の FAB 位置が従来通り（Web 版では変化なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)