### PR TITLE
fix: みんなで機能プロフィール統計と返信 UX の改善

### DIFF
--- a/backend/src/lib/supabase.ts
+++ b/backend/src/lib/supabase.ts
@@ -2646,7 +2646,8 @@ export const getSocialProfile = async (
   // biome-ignore lint/suspicious/noExplicitAny: enrichSocialPosts の返り値型は動的に構築される
   posts: any[];
   total_favorites?: number;
-  total_pages: number;
+  total_posts_count: number;
+  total_training_records_count: number;
   public_pages: { id: string; title: string; created_at: string }[];
 } | null> => {
   const { data: user, error: userError } = await supabaseClient
@@ -2671,7 +2672,8 @@ export const getSocialProfile = async (
         is_restricted: true,
         user: null,
         posts: [],
-        total_pages: 0,
+        total_posts_count: 0,
+        total_training_records_count: 0,
         public_pages: [],
       };
     }
@@ -2685,15 +2687,21 @@ export const getSocialProfile = async (
           is_restricted: true,
           user: null,
           posts: [],
-          total_pages: 0,
+          total_posts_count: 0,
+          total_training_records_count: 0,
           public_pages: [],
         };
       }
     }
   }
 
-  // 公開投稿・稽古記録数・公開稽古記録を並列取得
-  const [postsResult, totalPagesResult, publicPagesResult] = await Promise.all([
+  // 投稿フィード・投稿タイプ別カウント・公開稽古記録を並列取得
+  const [
+    postsResult,
+    totalPostsCountResult,
+    totalTrainingRecordsCountResult,
+    publicPagesResult,
+  ] = await Promise.all([
     supabaseClient
       .from("SocialPost")
       .select("*")
@@ -2702,9 +2710,17 @@ export const getSocialProfile = async (
       .order("created_at", { ascending: false })
       .limit(20),
     supabaseClient
-      .from("TrainingPage")
+      .from("SocialPost")
       .select("*", { count: "exact", head: true })
-      .eq("user_id", targetUserId),
+      .eq("user_id", targetUserId)
+      .eq("is_deleted", false)
+      .eq("post_type", "post"),
+    supabaseClient
+      .from("SocialPost")
+      .select("*", { count: "exact", head: true })
+      .eq("user_id", targetUserId)
+      .eq("is_deleted", false)
+      .eq("post_type", "training_record"),
     supabaseClient
       .from("TrainingPage")
       .select("id, title, created_at")
@@ -2715,7 +2731,6 @@ export const getSocialProfile = async (
   ]);
 
   const posts = postsResult.data;
-  const totalPagesCount = totalPagesResult.count;
   const publicPages = publicPagesResult.data;
 
   // 投稿データをエンリッチ（author, attachments, tags, hashtags, is_favorited 等を付与）
@@ -2731,28 +2746,42 @@ export const getSocialProfile = async (
     // biome-ignore lint/suspicious/noExplicitAny: enrichSocialPosts の返り値型は動的に構築される
     posts: any[];
     total_favorites?: number;
-    total_pages: number;
+    total_posts_count: number;
+    total_training_records_count: number;
     public_pages: { id: string; title: string; created_at: string }[];
   } = {
     is_restricted: false,
     user,
     posts: enrichedPosts,
-    total_pages: totalPagesCount ?? 0,
+    total_posts_count: totalPostsCountResult.count ?? 0,
+    total_training_records_count: totalTrainingRecordsCountResult.count ?? 0,
     public_pages: publicPages ?? [],
   };
 
-  // 本人のみ累計お気に入り数を返却
+  // 本人のみお気に入りされた数を返却（投稿＋返信の合算）
   if (targetUserId === viewerId) {
-    const { data: favData } = await supabaseClient
-      .from("SocialPost")
-      .select("favorite_count")
-      .eq("user_id", targetUserId)
-      .eq("is_deleted", false);
+    const [postFavRes, replyFavRes] = await Promise.all([
+      supabaseClient
+        .from("SocialPost")
+        .select("favorite_count")
+        .eq("user_id", targetUserId)
+        .eq("is_deleted", false),
+      supabaseClient
+        .from("SocialReply")
+        .select("favorite_count")
+        .eq("user_id", targetUserId)
+        .eq("is_deleted", false),
+    ]);
 
-    result.total_favorites = (favData ?? []).reduce(
+    const postSum = (postFavRes.data ?? []).reduce(
       (sum, p) => sum + (p.favorite_count ?? 0),
       0,
     );
+    const replySum = (replyFavRes.data ?? []).reduce(
+      (sum, r) => sum + (r.favorite_count ?? 0),
+      0,
+    );
+    result.total_favorites = postSum + replySum;
   }
 
   return result;
@@ -2775,7 +2804,8 @@ export const getPublicSocialProfile = async (
   } | null;
   // biome-ignore lint/suspicious/noExplicitAny: enrichSocialPosts の返り値型は動的に構築される
   posts: any[];
-  total_pages: number;
+  total_posts_count: number;
+  total_training_records_count: number;
   public_pages: { id: string; title: string; created_at: string }[];
 } | null> => {
   const { data: user, error: userError } = await supabaseClient
@@ -2796,14 +2826,20 @@ export const getPublicSocialProfile = async (
       is_restricted: true,
       user: null,
       posts: [],
-      total_pages: 0,
+      total_posts_count: 0,
+      total_training_records_count: 0,
       public_pages: [],
     };
   }
 
   const targetUserId = user.id;
 
-  const [postsResult, totalPagesResult, publicPagesResult] = await Promise.all([
+  const [
+    postsResult,
+    totalPostsCountResult,
+    totalTrainingRecordsCountResult,
+    publicPagesResult,
+  ] = await Promise.all([
     supabaseClient
       .from("SocialPost")
       .select("*")
@@ -2812,9 +2848,17 @@ export const getPublicSocialProfile = async (
       .order("created_at", { ascending: false })
       .limit(20),
     supabaseClient
-      .from("TrainingPage")
+      .from("SocialPost")
       .select("*", { count: "exact", head: true })
-      .eq("user_id", targetUserId),
+      .eq("user_id", targetUserId)
+      .eq("is_deleted", false)
+      .eq("post_type", "post"),
+    supabaseClient
+      .from("SocialPost")
+      .select("*", { count: "exact", head: true })
+      .eq("user_id", targetUserId)
+      .eq("is_deleted", false)
+      .eq("post_type", "training_record"),
     supabaseClient
       .from("TrainingPage")
       .select("id, title, created_at")
@@ -2831,7 +2875,8 @@ export const getPublicSocialProfile = async (
     is_restricted: false,
     user,
     posts: enrichedPosts,
-    total_pages: totalPagesResult.count ?? 0,
+    total_posts_count: totalPostsCountResult.count ?? 0,
+    total_training_records_count: totalTrainingRecordsCountResult.count ?? 0,
     public_pages: publicPagesResult.data ?? [],
   };
 };

--- a/frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx
+++ b/frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx
@@ -40,7 +40,8 @@ interface ProfileData {
   } | null;
   posts: SocialFeedPostData[];
   total_favorites?: number;
-  total_pages: number;
+  total_posts_count: number;
+  total_training_records_count: number;
   public_pages: { id: string; title: string; created_at: string }[];
 }
 
@@ -294,11 +295,15 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
       <div className={styles.statsSection}>
         <div className={styles.stats}>
           <div className={styles.statItem}>
-            <span className={styles.statValue}>{profile.posts.length}</span>
+            <span className={styles.statValue}>
+              {profile.total_posts_count}
+            </span>
             <span className={styles.statLabel}>{t("userPosts")}</span>
           </div>
           <div className={styles.statItem}>
-            <span className={styles.statValue}>{profile.total_pages}</span>
+            <span className={styles.statValue}>
+              {profile.total_training_records_count}
+            </span>
             <span className={styles.statLabel}>{t("trainingRecords")}</span>
           </div>
           <div className={styles.statItem}>

--- a/frontend/src/components/features/social/SocialReplyForm/SocialReplyForm.tsx
+++ b/frontend/src/components/features/social/SocialReplyForm/SocialReplyForm.tsx
@@ -4,6 +4,7 @@ import { PaperPlaneRightIcon } from "@phosphor-icons/react";
 import { useTranslations } from "next-intl";
 import { type FC, useCallback, useState } from "react";
 import { Button } from "@/components/shared/Button/Button";
+import { useIsDesktop } from "@/lib/hooks/useIsDesktop";
 import styles from "./SocialReplyForm.module.css";
 
 const MAX_REPLY_LENGTH = 1000;
@@ -14,6 +15,7 @@ interface SocialReplyFormProps {
 
 export const SocialReplyForm: FC<SocialReplyFormProps> = ({ onSubmit }) => {
   const t = useTranslations("socialPosts");
+  const isDesktop = useIsDesktop();
   const [content, setContent] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -41,6 +43,8 @@ export const SocialReplyForm: FC<SocialReplyFormProps> = ({ onSubmit }) => {
           maxLength={MAX_REPLY_LENGTH}
           rows={1}
           onKeyDown={(e) => {
+            // SP では Enter を改行用に開放し、送信はボタン操作のみに限定
+            if (!isDesktop) return;
             if (
               e.key === "Enter" &&
               !e.shiftKey &&

--- a/frontend/src/lib/hooks/useIsDesktop.ts
+++ b/frontend/src/lib/hooks/useIsDesktop.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const DESKTOP_QUERY = "(min-width: 431px)";
+
+export const useIsDesktop = (): boolean => {
+  const [isDesktop, setIsDesktop] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(DESKTOP_QUERY);
+    const update = () => setIsDesktop(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  return isDesktop;
+};

--- a/frontend/src/server/trpc/procedures.ts
+++ b/frontend/src/server/trpc/procedures.ts
@@ -800,7 +800,8 @@ type SocialProfileData = {
   } | null;
   posts: SocialFeedPost[];
   total_favorites?: number;
-  total_pages: number;
+  total_posts_count: number;
+  total_training_records_count: number;
   public_pages: { id: string; title: string; created_at: string }[];
 };
 

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -749,7 +749,7 @@
     "myPosts": "My Posts",
     "userPosts": "Posts",
     "trainingRecords": "Training Records",
-    "totalFavorites": "Total Favorites",
+    "totalFavorites": "Favorites Received",
     "otherUserFavoritesHidden": "Other users' favorite counts are not visible",
     "profileTabPosts": "Posts",
     "profileTabTraining": "Training Records",

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -751,7 +751,7 @@
     "myPosts": "自分の投稿",
     "userPosts": "投稿",
     "trainingRecords": "稽古記録",
-    "totalFavorites": "累計お気に入り数",
+    "totalFavorites": "お気に入りされた数",
     "otherUserFavoritesHidden": "他のユーザーのお気に入り数は閲覧できません",
     "profileTabPosts": "投稿",
     "profileTabTraining": "稽古記録",


### PR DESCRIPTION
## Summary

- プロフィール画面 (/social/profile/[username]) の「投稿」「稽古記録」カウントを `SocialPost.post_type` ベースの正確な集計に変更（稽古記録タイプ投稿が両方に +1 される不具合を解消）
- 「累計お気に入り数」を「お気に入りされた数」にラベル変更し、投稿だけでなく返信（SocialReply）への ♥ も合算するよう集計ロジック拡張
- スマホでの返信フォーム送信 UX を改善: SP 幅（< 431px）では Enter が改行に、送信ボタンのみで submit されるように（PC は従来どおり Enter で送信）

## 変更内容

### バックエンド
- `backend/src/lib/supabase.ts` の `getSocialProfile` / `getPublicSocialProfile`
  - `total_pages` フィールドを廃止し、`total_posts_count`（post_type='post'）と `total_training_records_count`（post_type='training_record'）を返却
  - 本人向け `total_favorites` を `SocialPost.favorite_count` + `SocialReply.favorite_count` の合算に変更

### フロントエンド
- `frontend/src/lib/hooks/useIsDesktop.ts` を新規追加（`window.matchMedia("(min-width: 431px)")` ベース、SSR 安全）
- `SocialReplyForm.tsx` の `onKeyDown` に SP 判定ガードを追加
- `SocialProfileView.tsx` / tRPC 型定義を新フィールドに追従
- `ja.json` / `en.json` の `totalFavorites` 翻訳値を更新

## Test plan

- [ ] 自分のプロフィールで、通常投稿を追加 → 「投稿」が +1、「稽古記録」は不変
- [ ] 稽古記録タイプの投稿を追加 → 「稽古記録」が +1、「投稿」は不変
- [ ] 個人ページで TrainingPage を作っただけ（未公開）→ 「稽古記録」は変わらないこと
- [ ] 他ユーザーから自分の投稿へ ♥ → 「お気に入りされた数」+1
- [ ] 他ユーザーから自分の返信へ ♥ → 「お気に入りされた数」+1（新挙動）
- [ ] 他ユーザーのプロフィール閲覧時「???」表示が維持されていること
- [ ] 翻訳: ja で「お気に入りされた数」、en で "Favorites Received" と表示されること
- [ ] DevTools でビューポートを < 431px に → 返信テキストエリアで Enter 押下 → 改行されて送信されない
- [ ] 紙飛行機ボタンで送信できること
- [ ] ビューポートを ≥ 431px → Enter で送信されること
- [ ] IME 合成中の Enter では PC でも送信されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)