### PR TITLE
refactor: ページネーション取得件数のマジックナンバーを定数化し命名を統一

### DIFF
--- a/frontend/src/lib/hooks/useNotifications.ts
+++ b/frontend/src/lib/hooks/useNotifications.ts
@@ -32,7 +32,7 @@ interface UseNotificationsReturn {
   loadMore: () => void;
 }
 
-const LIMIT = 20;
+const NOTIFICATIONS_FETCH_LIMIT = 20;
 
 export function useNotifications(
   tab: NotificationTab,
@@ -54,7 +54,7 @@ export function useNotifications(
       try {
         const typeFilter = tab === "all" ? undefined : tab;
         const result = await getNotifications({
-          limit: LIMIT,
+          limit: NOTIFICATIONS_FETCH_LIMIT,
           offset,
           type: typeFilter,
         });
@@ -66,7 +66,7 @@ export function useNotifications(
 
         setNotifications((prev) => (append ? [...prev, ...items] : items));
         offsetRef.current = offset + items.length;
-        setHasMore(items.length >= LIMIT);
+        setHasMore(items.length >= NOTIFICATIONS_FETCH_LIMIT);
       } catch {
         setHasMore(false);
       }

--- a/frontend/src/lib/hooks/useSocialFeed.ts
+++ b/frontend/src/lib/hooks/useSocialFeed.ts
@@ -36,7 +36,7 @@ interface UseSocialFeedResult {
   ) => void;
 }
 
-const LIMIT = 20;
+const SOCIAL_FEED_FETCH_LIMIT = 20;
 
 export function useSocialFeed(
   userId: string | undefined,
@@ -60,7 +60,7 @@ export function useSocialFeed(
         const params: GetSocialFeedParams = {
           userId,
           tab: targetTab,
-          limit: LIMIT,
+          limit: SOCIAL_FEED_FETCH_LIMIT,
           offset,
         };
 
@@ -75,7 +75,7 @@ export function useSocialFeed(
           [targetTab]: {
             posts: append ? [...prev[targetTab].posts, ...newPosts] : newPosts,
             offset: offset + newPosts.length,
-            hasMore: newPosts.length >= LIMIT,
+            hasMore: newPosts.length >= SOCIAL_FEED_FETCH_LIMIT,
             initialLoading: false,
           },
         }));

--- a/frontend/src/lib/hooks/useSocialSearch.ts
+++ b/frontend/src/lib/hooks/useSocialSearch.ts
@@ -24,7 +24,7 @@ interface UseSocialSearchResult {
 }
 
 const DEBOUNCE_MS = 400;
-const LIMIT = 20;
+const SOCIAL_SEARCH_FETCH_LIMIT = 20;
 
 export function useSocialSearch(
   userId: string | undefined,
@@ -58,7 +58,7 @@ export function useSocialSearch(
             rank: rank || undefined,
             hashtag: hashtag || undefined,
             postType: postType || undefined,
-            limit: LIMIT,
+            limit: SOCIAL_SEARCH_FETCH_LIMIT,
           };
           const result = await searchSocialPosts(params);
           if (result.success && result.data) {

--- a/frontend/src/lib/hooks/useTrainingPagesData.ts
+++ b/frontend/src/lib/hooks/useTrainingPagesData.ts
@@ -27,6 +27,8 @@ interface PageCreateData {
 // 楽観的更新用の一時的なプレフィックス
 const OPTIMISTIC_ID_PREFIX = "optimistic-";
 
+const TRAINING_PAGES_FETCH_LIMIT = 25;
+
 export interface FetchOptions {
   query?: string;
   tags?: string[];
@@ -81,7 +83,6 @@ export function useTrainingPagesData(options: FetchOptions = {}) {
       );
 
       try {
-        const limit = 25;
         const offset = isLoadMore
           ? allDataRef.current.filter(
               (p) => !p.id.startsWith(OPTIMISTIC_ID_PREFIX),
@@ -90,7 +91,7 @@ export function useTrainingPagesData(options: FetchOptions = {}) {
 
         const response = await getPages({
           userId: user.id,
-          limit,
+          limit: TRAINING_PAGES_FETCH_LIMIT,
           offset,
           query: options.query || "",
           tags: options.tags || [],


### PR DESCRIPTION
## Summary

- 稽古記録ページ一覧 (`/personal/pages/`) の初期ロード件数 `25` が `useTrainingPagesData.ts` 内でマジックナンバーとして書かれており、コードから初期表示件数を把握しづらかったため、top-level の定数 `TRAINING_PAGES_FETCH_LIMIT` に抽出しました
- 同種の他フック (`useNotifications.ts` / `useSocialFeed.ts` / `useSocialSearch.ts`) は既にローカル定数化されていたものの、命名が汎用的な `LIMIT` だったため `XXXX_FETCH_LIMIT` 形式に揃えて一貫性を確保しました
- 純粋な識別子リネームで、実行時挙動および公開 API (フックの引数・戻り値) は一切変わりません

## 変更内容

| ファイル | 変更 |
|---|---|
| `frontend/src/lib/hooks/useTrainingPagesData.ts` | ローカル `const limit = 25;` を削除し、top-level に `TRAINING_PAGES_FETCH_LIMIT = 25` を追加 |
| `frontend/src/lib/hooks/useNotifications.ts` | `LIMIT` → `NOTIFICATIONS_FETCH_LIMIT` |
| `frontend/src/lib/hooks/useSocialFeed.ts` | `LIMIT` → `SOCIAL_FEED_FETCH_LIMIT` |
| `frontend/src/lib/hooks/useSocialSearch.ts` | `LIMIT` → `SOCIAL_SEARCH_FETCH_LIMIT` |

## Test plan

- [x] `pnpm tsc --noEmit` (frontend) — エラーなし
- [x] 編集 4 ファイルでの Biome チェック — 警告ゼロ
- [x] pre-push フックでフロントエンド 276 tests / バックエンド 210 tests すべて pass
- [x] Next.js プロダクションビルド成功
- [x] `/ja/personal/pages/` で初期 25 件表示・「さらに読み込む」で次の 25 件追加を確認
- [x] `/ja/social/posts` (通知 / フィード / 検索) で 20 件単位のロードが従来通り動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)