### PR TITLE
feat: ネイティブアプリ連携バグ修正（ロゴ / Universal Links / OAuth）

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -52,6 +52,20 @@ const nextConfig = {
     return config;
   },
 
+  // Universal Links / App Links 用の .well-known ファイルを正しい Content-Type で配信
+  async headers() {
+    return [
+      {
+        source: "/.well-known/apple-app-site-association",
+        headers: [{ key: "Content-Type", value: "application/json" }],
+      },
+      {
+        source: "/.well-known/assetlinks.json",
+        headers: [{ key: "Content-Type", value: "application/json" }],
+      },
+    ];
+  },
+
   // 環境変数を明示的に設定（ビルド時とランタイム両方で利用可能）
   env: {
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/frontend/public/.well-known/apple-app-site-association
+++ b/frontend/public/.well-known/apple-app-site-association
@@ -1,0 +1,21 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["K2829N93YA.com.aikinote"],
+        "components": [
+          {
+            "/": "/verify-email",
+            "?": { "token": "?*" },
+            "comment": "Email verification deep link"
+          },
+          {
+            "/": "/*/verify-email",
+            "?": { "token": "?*" },
+            "comment": "Locale-prefixed email verification"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/public/.well-known/assetlinks.json
+++ b/frontend/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.aikinote",
+      "sha256_cert_fingerprints": [
+        "76:F8:3B:53:1E:EB:26:87:FA:75:49:5D:07:50:83:93:70:7F:6B:E2:59:9B:9A:4C:92:B1:A1:87:E6:47:E9:DC"
+      ]
+    }
+  }
+]

--- a/frontend/src/components/shared/layouts/common/DefaultHeader/DefaultHeader.tsx
+++ b/frontend/src/components/shared/layouts/common/DefaultHeader/DefaultHeader.tsx
@@ -37,6 +37,7 @@ export const DefaultHeader: FC<DefaultHeaderProps> = ({
 }) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isProfileCardOpen, setIsProfileCardOpen] = useState(false);
+  const [isNativeApp, setIsNativeApp] = useState(false);
   const profileCardRef = useRef<HTMLDivElement>(null);
   const { shouldShowTooltip, hideTooltip } = useTooltipVisibility();
   const tooltipId = "font-size-tooltip";
@@ -44,6 +45,13 @@ export const DefaultHeader: FC<DefaultHeaderProps> = ({
   const locale = useLocale();
   const t = useTranslations();
   const { track } = useUmamiTrack();
+
+  useEffect(() => {
+    setIsNativeApp(
+      !!(window as unknown as { __AIKINOTE_NATIVE_APP__?: boolean })
+        .__AIKINOTE_NATIVE_APP__,
+    );
+  }, []);
 
   const pathname = usePathname();
   const unreadCount = useUnreadNotificationCount(user?.id);
@@ -118,23 +126,30 @@ export const DefaultHeader: FC<DefaultHeaderProps> = ({
   }, [isProfileCardOpen]);
 
   const homeHref = `/${locale}`;
+  const logoImage = (
+    <Image
+      src="/images/shared/aikinote_logo.png"
+      alt="AikiNote"
+      width={56}
+      height={56}
+      priority
+      className={styles.logo}
+    />
+  );
 
   return (
     <header className={styles.header} data-testid="default-header">
-      <Link
-        href={homeHref}
-        className={styles.logoLink}
-        aria-label="ホームに移動"
-      >
-        <Image
-          src="/images/shared/aikinote_logo.png"
-          alt="AikiNote"
-          width={56}
-          height={56}
-          priority
-          className={styles.logo}
-        />
-      </Link>
+      {isNativeApp ? (
+        <div className={styles.logoLink}>{logoImage}</div>
+      ) : (
+        <Link
+          href={homeHref}
+          className={styles.logoLink}
+          aria-label="ホームに移動"
+        >
+          {logoImage}
+        </Link>
+      )}
 
       <div className={styles.headerRight}>
         {user && (

--- a/frontend/src/lib/hooks/useAuth.ts
+++ b/frontend/src/lib/hooks/useAuth.ts
@@ -267,13 +267,34 @@ export function useAuth() {
   );
 
   const signInWithGoogle = useCallback(async () => {
-    // ネイティブアプリの場合はブリッジに委譲
+    // ネイティブアプリの場合はブリッジに委譲し、結果を待つ
+    const nativeBridge = window as unknown as {
+      __AIKINOTE_NATIVE_APP__?: boolean;
+      startNativeOAuth?: (
+        provider: "google" | "apple",
+      ) => Promise<{ success: boolean; reason?: string; message?: string }>;
+    };
     if (
       typeof window !== "undefined" &&
-      (window as any).__AIKINOTE_NATIVE_APP__ &&
-      typeof (window as any).startNativeOAuth === "function"
+      nativeBridge.__AIKINOTE_NATIVE_APP__ &&
+      typeof nativeBridge.startNativeOAuth === "function"
     ) {
-      (window as any).startNativeOAuth("google");
+      setIsProcessing(true);
+      setError(null);
+      try {
+        const result = await nativeBridge.startNativeOAuth("google");
+        if (!result?.success) {
+          const reason = result?.reason ?? "unknown";
+          const message =
+            reason === "cancel" || reason === "dismiss"
+              ? "Googleログインがキャンセルされました"
+              : "Googleログインに失敗しました。もう一度お試しください。";
+          setError(message);
+          throw new Error(message);
+        }
+      } finally {
+        setIsProcessing(false);
+      }
       return;
     }
 
@@ -302,13 +323,34 @@ export function useAuth() {
   }, [supabase.auth]);
 
   const signInWithApple = useCallback(async () => {
-    // ネイティブアプリの場合はブリッジに委譲
+    // ネイティブアプリの場合はブリッジに委譲し、結果を待つ
+    const nativeBridge = window as unknown as {
+      __AIKINOTE_NATIVE_APP__?: boolean;
+      startNativeOAuth?: (
+        provider: "google" | "apple",
+      ) => Promise<{ success: boolean; reason?: string; message?: string }>;
+    };
     if (
       typeof window !== "undefined" &&
-      (window as any).__AIKINOTE_NATIVE_APP__ &&
-      typeof (window as any).startNativeOAuth === "function"
+      nativeBridge.__AIKINOTE_NATIVE_APP__ &&
+      typeof nativeBridge.startNativeOAuth === "function"
     ) {
-      (window as any).startNativeOAuth("apple");
+      setIsProcessing(true);
+      setError(null);
+      try {
+        const result = await nativeBridge.startNativeOAuth("apple");
+        if (!result?.success) {
+          const reason = result?.reason ?? "unknown";
+          const message =
+            reason === "cancel" || reason === "dismiss"
+              ? "Appleログインがキャンセルされました"
+              : "Appleログインに失敗しました。もう一度お試しください。";
+          setError(message);
+          throw new Error(message);
+        }
+      } finally {
+        setIsProcessing(false);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

実機テストで発覚したネイティブアプリ連携の 3 件の不具合を修正する Web 側の変更。ネイティブアプリ側の変更は別 PR（`aikinote-native-app` リポジトリ）で対応。

- **ロゴ遷移の抑止**: ネイティブアプリ版の `/login` / `/signup` ヘッダー左上のロゴを押すとランディングページに戻ってしまう不具合。`window.__AIKINOTE_NATIVE_APP__` 検知時は `<Link>` を外して遷移を抑制
- **メール認証の Universal Links / App Links 対応**: `public/.well-known/apple-app-site-association` と `assetlinks.json` を新規配置し、メール内の `https://aikinote.com/verify-email?token=xxx` をタップした際に OS がアプリへ自動遷移する仕組みを有効化。`next.config.js` の `headers()` で `Content-Type: application/json` を固定。AASA 対象は `/verify-email*` のみで、`/auth/callback` は含めない（Web OAuth の既存挙動を保持）
- **OAuth 失敗理由の可視化**: ネイティブアプリ側が Promise を返す `startNativeOAuth` ブリッジに対応。Web 側の `useAuth.signInWithGoogle` / `signInWithApple` で結果を `await` し、失敗時は `setError` で日本語メッセージをユーザーに提示

## 前提情報

- **Apple Team ID**: `K2829N93YA`
- **Android SHA256** (production keystore): `76:F8:3B:53:1E:EB:26:87:FA:...:DC`

これらを AASA / assetlinks.json に反映済み。

## Test plan

- [ ] Vercel prod デプロイ後、`https://aikinote.com/.well-known/apple-app-site-association` が 200 + `Content-Type: application/json` で返ることを確認
- [ ] 同様に `https://aikinote.com/.well-known/assetlinks.json` を確認
- [ ] Apple 公式 validator (`https://search.developer.apple.com/appsearch-validation-tool/`) に通る
- [ ] Google 公式 validator (`https://developers.google.com/digital-asset-links/tools/generator`) に通る
- [ ] Web ブラウザ `/ja/login` のロゴ押下 → `/ja` へ遷移（既存挙動維持）
- [ ] ネイティブアプリ（別 PR のビルド）で `/login` のロゴ押下 → 遷移しない
- [ ] ネイティブアプリで新規登録 → メール受信 → リンクタップ → AikiNote アプリ起動 → `/verify-email` 処理 → `/personal/pages` 遷移
- [x] ネイティブアプリの OAuth 失敗時に Web 側 toast / inline エラーが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)