### PR TITLE
chore: 認証・クエリクライアント基盤のパフォーマンス最適化

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/mypage/MyPage.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/mypage/MyPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import type { UserProfile } from "@/components/features/personal/MyPageContent/MyPageContent";
 import { MyPageContent } from "@/components/features/personal/MyPageContent/MyPageContent";
 import { SurveyModal } from "@/components/shared/SurveyModal/SurveyModal";
@@ -18,7 +18,9 @@ interface MyPageProps {
 export default function MyPage({ initialUser }: MyPageProps) {
   const t = useTranslations();
   const [user, setUser] = useState<UserProfile>(initialUser);
-  const [loading, setLoading] = useState(true);
+  // サーバー側で全フィールドが初期化済みなので、マウント時の loading は不要。
+  // ミューテーション後の再取得時のみ true にする
+  const [loading, setLoading] = useState(false);
   const { showToast } = useToast();
   const { track } = useUmamiTrack();
 
@@ -42,11 +44,6 @@ export default function MyPage({ initialUser }: MyPageProps) {
       setLoading(false);
     }
   }, [showToast, t, user.id]);
-
-  // マイページアクセス時に最新のユーザー情報を取得
-  useEffect(() => {
-    fetchUserInfo();
-  }, [fetchUserInfo]);
 
   const { isOpen: isSurveyOpen, dismiss: dismissSurvey } = useSurveyModal({
     ageRange: user.age_range ?? null,

--- a/frontend/src/app/[locale]/(authenticated)/mypage/page.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/mypage/page.tsx
@@ -41,14 +41,22 @@ export default async function Page({
     redirect(loginPath);
   }
 
+  // サーバー側で Hono から取得した全フィールドを初期値として渡すことで、
+  // クライアント側の初期 fetch を不要にし、MyPage の LCP を短縮する
   const initialProfile = {
     id: user.id,
     email: user.email || "",
     username: user.username || userInfoT("usernamePlaceholder"),
     profile_image_url: user.profile_image_url || null,
     dojo_style_name: user.dojo_style_name || null,
-    training_start_date: null,
-    publicity_setting: "private" as const,
+    dojo_style_id: user.dojo_style_id || null,
+    training_start_date: user.training_start_date || null,
+    publicity_setting: user.publicity_setting || null,
+    aikido_rank: user.aikido_rank || null,
+    full_name: user.full_name || null,
+    bio: user.bio ?? null,
+    age_range: user.age_range ?? null,
+    gender: user.gender ?? null,
     language: locale,
     is_email_verified: true,
     password_hash: "",

--- a/frontend/src/components/features/social/SocialFeedHeader/SocialFeedHeader.tsx
+++ b/frontend/src/components/features/social/SocialFeedHeader/SocialFeedHeader.tsx
@@ -9,7 +9,7 @@ import {
 } from "@phosphor-icons/react";
 import { usePathname } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
-import { type FC, useEffect } from "react";
+import { type FC, useEffect, useRef } from "react";
 import { SocialHeader } from "@/components/shared/layouts/SocialLayout";
 import { ProfileImage } from "@/components/shared/ProfileImage/ProfileImage";
 import { useAuth } from "@/lib/hooks/useAuth";
@@ -30,9 +30,12 @@ export const SocialFeedHeader: FC<SocialFeedHeaderProps> = ({
   const pathname = usePathname();
   const { user } = useAuth();
   const unreadCount = useUnreadNotificationCount(user?.id);
+  const lastSentUnreadCountRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    // 値が変わっていない場合はネイティブへの postMessage を送らない（重複通知の抑制）
+    if (lastSentUnreadCountRef.current === unreadCount) return;
     const w = window as unknown as {
       __AIKINOTE_NATIVE_APP__?: boolean;
       ReactNativeWebView?: { postMessage: (msg: string) => void };
@@ -44,6 +47,7 @@ export const SocialFeedHeader: FC<SocialFeedHeaderProps> = ({
           payload: { count: unreadCount },
         }),
       );
+      lastSentUnreadCountRef.current = unreadCount;
     }
   }, [unreadCount]);
 

--- a/frontend/src/components/shared/providers/QueryProvider.tsx
+++ b/frontend/src/components/shared/providers/QueryProvider.tsx
@@ -29,7 +29,8 @@ export function QueryProvider({ children }: { children: ReactNode }) {
         client={queryClient}
         persistOptions={{
           persister,
-          maxAge: 24 * 60 * 60 * 1000,
+          // 古い空キャッシュの残留で「まだ投稿がありません」等の誤表示が長引くのを避けるため 12h に短縮
+          maxAge: 12 * 60 * 60 * 1000,
           dehydrateOptions: {
             shouldDehydrateQuery: (query) =>
               query.state.status === "success" && Boolean(query.state.data),

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -23,6 +23,8 @@ export type UserSession = {
   publicity_setting?: string | null;
   age_range?: string | null;
   gender?: string | null;
+  bio?: string | null;
+  training_start_date?: string | null;
 };
 
 export async function signUp(credentials: SignUpCredentials) {

--- a/frontend/src/lib/hooks/useAuth.ts
+++ b/frontend/src/lib/hooks/useAuth.ts
@@ -102,12 +102,14 @@ export function useAuth() {
       setIsInitializing(true);
       try {
         // タイムアウト付きでセッション取得
+        // 不安定なネットワーク下での「開かない」体感を避けるため、3 秒で打ち切り、
+        // タイムアウト時は未ログイン扱いで UI を先に出す（onAuthStateChange が後追いで復帰させる）
         const sessionPromise: Promise<SessionResponse> =
           supabaseClient.auth.getSession();
         const timeoutPromise = new Promise<never>((_, reject) =>
           setTimeout(
             () => reject(new Error("セッション取得がタイムアウトしました")),
-            10000,
+            3000,
           ),
         );
 

--- a/frontend/src/lib/hooks/useUnreadNotificationCount.ts
+++ b/frontend/src/lib/hooks/useUnreadNotificationCount.ts
@@ -7,7 +7,9 @@ import {
   getUnreadNotificationPostIds,
 } from "@/lib/api/client";
 
-const POLLING_INTERVAL_MS = 60_000;
+// ネイティブアプリ同梱の WebView/バックグラウンド動作を考慮し、SP でのバッテリー・帯域を優先して長めに設定。
+// タブ復帰直後は `refetchOnWindowFocus: true` で即反映されるので、polling 間隔を延長しても体感差は小さい。
+const POLLING_INTERVAL_MS = 120_000;
 
 export const unreadNotificationCountQueryKey = (userId: string | undefined) =>
   ["unread-notification-count", userId] as const;
@@ -22,6 +24,8 @@ export function useUnreadNotificationCount(userId: string | undefined): number {
     queryFn: () => getUnreadNotificationCount(),
     refetchInterval: POLLING_INTERVAL_MS,
     refetchIntervalInBackground: false,
+    // タブ復帰直後に次の polling を待たず即反映したいので、通知系はフォーカス時 refetch を明示的に有効化
+    refetchOnWindowFocus: true,
   });
 
   return query.data ?? 0;
@@ -34,6 +38,7 @@ export function useUnreadReplyPostIds(userId: string | undefined): Set<string> {
     queryFn: () => getUnreadNotificationPostIds(),
     refetchInterval: POLLING_INTERVAL_MS,
     refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
   });
 
   return useMemo(() => new Set(query.data ?? []), [query.data]);

--- a/frontend/src/lib/query/query-client.ts
+++ b/frontend/src/lib/query/query-client.ts
@@ -6,7 +6,9 @@ function makeQueryClient(): QueryClient {
       queries: {
         staleTime: 30 * 1000,
         gcTime: 5 * 60 * 1000,
-        refetchOnWindowFocus: true,
+        // モバイルでの帯域・バッテリー消費を抑えるため、フォーカス時の自動 refetch はデフォルト OFF
+        // 通知カウントなどフォーカス復帰時に追随させたいクエリは個別に `refetchOnWindowFocus: true` を指定する
+        refetchOnWindowFocus: false,
         refetchOnReconnect: true,
         retry: 1,
       },

--- a/frontend/src/lib/server/auth.ts
+++ b/frontend/src/lib/server/auth.ts
@@ -23,6 +23,10 @@ type HonoUserInfo = {
   training_start_date?: string | null;
   aikido_rank?: string | null;
   full_name?: string | null;
+  bio?: string | null;
+  publicity_setting?: string | null;
+  age_range?: string | null;
+  gender?: string | null;
 };
 
 export const buildApiUrl = (path: string) => {
@@ -100,6 +104,11 @@ export const fetchUserInfoFromHono = async (
     dojo_style_id: data.dojo_style_id || null,
     aikido_rank: data.aikido_rank || null,
     full_name: data.full_name || null,
+    bio: data.bio ?? null,
+    publicity_setting: data.publicity_setting ?? null,
+    age_range: data.age_range ?? null,
+    gender: data.gender ?? null,
+    training_start_date: data.training_start_date ?? null,
   };
 };
 

--- a/frontend/src/lib/supabase/client.ts
+++ b/frontend/src/lib/supabase/client.ts
@@ -17,13 +17,24 @@ if (!supabaseUrl || !supabaseAnonKey) {
   );
 }
 
+// GoTrueClient は複数インスタンスを立てると認証状態が不整合になりうるため、
+// モジュールスコープで singleton を維持する。
+// 型は createBrowserClient の呼び出し結果から具体型が推論されるよう、
+// 一旦ローカル関数を経由して ReturnType を取る（generic 直参照だとジェネリクスが展開されず any 化する）
+const buildBrowserClient = () => {
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Supabase environment variables are missing");
+  }
+  return createBrowserClient(supabaseUrl, supabaseAnonKey);
+};
+
+let cachedClient: ReturnType<typeof buildBrowserClient> | undefined;
+
 export function getClientSupabase() {
+  if (cachedClient) return cachedClient;
   try {
-    if (!supabaseUrl || !supabaseAnonKey) {
-      throw new Error("Supabase environment variables are missing");
-    }
-    const client = createBrowserClient(supabaseUrl, supabaseAnonKey);
-    return client;
+    cachedClient = buildBrowserClient();
+    return cachedClient;
   } catch (error) {
     console.error("getClientSupabase: クライアント作成エラー", error);
     throw error;


### PR DESCRIPTION
## Summary
UX / パフォーマンス改善の第 1 弾。主要 3 画面の体感速度に直結する **認証・クエリクライアント基盤** をまとめてチューニング。後続 PR でリスト UX / 画像最適化を予定。

### 変更内容

- **Supabase クライアントを singleton 化** (`frontend/src/lib/supabase/client.ts`)
  - `getClientSupabase()` が呼ばれる度に `createBrowserClient` を呼び直していたのを、モジュールスコープのキャッシュで一意化。
  - `GoTrueClient` を複数インスタンス立てることによる認証状態不整合の芽を摘む。
- **TanStack Query の `refetchOnWindowFocus` デフォルトを OFF に** (`frontend/src/lib/query/query-client.ts`)
  - モバイルでタブ復帰するたびに全 active query が一斉 refetch されるのを抑制（帯域・バッテリー消費に効く）。
  - 通知カウント / 未読 post IDs は「タブ復帰直後に即反映したい」性質なので、個別に `refetchOnWindowFocus: true` を維持。
- **`useAuth` のセッション取得タイムアウト 10s → 3s** (`frontend/src/lib/hooks/useAuth.ts`)
  - ネットワーク不調時、アプリが 10 秒間「開かない」体感になるのを回避。タイムアウト時は未ログイン扱いで UI を先に出し、後追いで `onAuthStateChange` が状態を復帰させる。
- **MyPage の二重 user 取得を解消** (`frontend/src/app/[locale]/(authenticated)/mypage/{page,MyPage}.tsx` + `frontend/src/lib/server/auth.ts` + `frontend/src/lib/auth.ts`)
  - サーバー側 `fetchUserInfoFromHono` が `bio` / `age_range` / `gender` / `publicity_setting` / `training_start_date` を取り落としていたため、クライアント側でマウント直後に再 fetch する必要があった。
  - これらのフィールドを `UserSession` / 初期プロフィールまで貫通させることで、クライアントの初期 `getUserInfo()` 呼び出しを撤廃。アンケート保存後など、明示的なリフレッシュ契機のみ `fetchUserInfo` を走らせる形に。
- **PersistQueryClient `maxAge` 24h → 12h** (`frontend/src/components/shared/providers/QueryProvider.tsx`)
  - 古い空キャッシュが「まだ投稿がありません」等の誤表示で残る期間を短縮。
- **通知ポーリングの最適化** (`frontend/src/lib/hooks/useUnreadNotificationCount.ts` + `frontend/src/components/features/social/SocialFeedHeader/SocialFeedHeader.tsx`)
  - polling 間隔を 60s → 120s に延長。`refetchOnWindowFocus: true` を明示したので、タブ復帰直後は即追随。
  - ネイティブアプリへの `ReactNativeWebView.postMessage` を前回送信値とのメモ化で差分送信化。同値 count での重複通知を防ぐ。

## Test plan
- [x] `pnpm check`（Biome）が緑
- [x] `pnpm test`（frontend/backend 合算 486 テスト）が緑
- [x] `pnpm tsc --noEmit`（frontend）がエラーなし
- [x] `/ja/mypage` 初期表示で「ユーザー情報取得中...」スケルトンが出ずに SSR データで即描画される
- [x] 投稿一覧・ページ一覧の初期表示挙動に変化がない（直近 fix の回帰なし）
- [x] タブを別アプリに切り替えて戻ってきたときに、通知バッジのみ即更新される（他のクエリは refetch しない）
- [x] ネイティブアプリでのログイン / ログアウト / セッション復帰が正常に機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)