### PR TITLE
chore: リストビューと画面遷移の UX 改善

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
@@ -45,8 +45,6 @@ export function PersonalPages() {
   const [isSortDropdownOpen, setIsSortDropdownOpen] = useState(false);
   const sortDropdownRef = useRef<HTMLDivElement>(null);
 
-  // Custom Hooks
-  const { availableTags } = useTrainingTags();
   const {
     searchQuery,
     setSearchQuery,
@@ -91,6 +89,10 @@ export function PersonalPages() {
     isTagModalOpen,
     setIsTagModalOpen,
   } = useTrainingPageModals();
+
+  // タグ一覧はタグフィルタモーダルを開くまで画面に出ないので、初回ロード時の不要フェッチを避けるため遅延取得する。
+  // 一度取得すれば TanStack Query のキャッシュに残るため、2 回目以降のモーダル起動は即時反映される
+  const { availableTags } = useTrainingTags({ enabled: isTagModalOpen });
 
   // ソートドロップダウン外クリックで閉じる
   const handleClickOutside = useCallback((event: MouseEvent) => {

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/loading.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/loading.tsx
@@ -1,0 +1,14 @@
+import { TrainingCardSkeleton } from "@/components/features/personal/TrainingCard/TrainingCardSkeleton";
+import { DefaultLayout } from "@/components/shared/layouts/DefaultLayout";
+
+// ページ一覧 → 詳細 への遷移時、Header/Footer を保ったままスケルトンを見せることで
+// 画面が一瞬真っ白になる違和感を抑える
+export default function Loading() {
+  return (
+    <DefaultLayout>
+      <div style={{ padding: "16px" }}>
+        <TrainingCardSkeleton count={1} />
+      </div>
+    </DefaultLayout>
+  );
+}

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/SocialPostsFeed.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/SocialPostsFeed.tsx
@@ -64,7 +64,6 @@ export function SocialPostsFeed() {
   const { track } = useUmamiTrack();
   const { canPost, isPremium, loading: dailyLimitsLoading } = useDailyLimits();
   const unreadReplyPostIds = useUnreadReplyPostIds(user?.id);
-  const sentinelRef = useRef<HTMLDivElement>(null);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [upgradeModalKey, setUpgradeModalKey] =
     useState<string>("premiumModalBrowse");
@@ -105,26 +104,44 @@ export function SocialPostsFeed() {
     });
 
   // Intersection Observer で無限スクロール
+  // isLoading / hasMore / isLoadingMore の変化で observer を作り直すと、
+  // タブ切替やデータ更新のたびに観測がリセットされて取りこぼしやちらつきに繋がる。
+  // volatile な値は ref 経由で参照し、sentinel ノードのマウント時に 1 度だけ observer を生成する
   const loadMoreRef = useRef(loadMore);
   loadMoreRef.current = loadMore;
+  const hasMoreRef = useRef(hasMore);
+  hasMoreRef.current = hasMore;
+  const isLoadingMoreRef = useRef(isLoadingMore);
+  isLoadingMoreRef.current = isLoadingMore;
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
-  useEffect(() => {
-    if (isLoading) return;
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
+  const setSentinelRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && hasMore && !isLoadingMore) {
+        if (
+          entries[0].isIntersecting &&
+          hasMoreRef.current &&
+          !isLoadingMoreRef.current
+        ) {
           loadMoreRef.current();
         }
       },
       { rootMargin: "200px" },
     );
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
 
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [hasMore, isLoadingMore, isLoading]);
+  useEffect(() => {
+    return () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+    };
+  }, []);
 
   const handleFavoriteToggle = useCallback(
     (postId: string) => {
@@ -205,7 +222,7 @@ export function SocialPostsFeed() {
               />
             ))}
 
-            <div ref={sentinelRef} className={styles.sentinel}>
+            <div ref={setSentinelRef} className={styles.sentinel}>
               {isLoadingMore && <Loader size="large" centered />}
               {!hasMore && posts.length > 0 && (
                 <p className={styles.noMore}>{t("noMorePosts")}</p>

--- a/frontend/src/app/[locale]/(public)/social/posts/[post_id]/loading.tsx
+++ b/frontend/src/app/[locale]/(public)/social/posts/[post_id]/loading.tsx
@@ -1,0 +1,13 @@
+import { Loader } from "@/components/shared/Loader";
+import { ChatLayout } from "@/components/shared/layouts/ChatLayout";
+
+// 投稿一覧 → 詳細 への遷移中も ChatLayout（フッター固定）を保ち、レイアウト揺れを防ぐ
+export default function Loading() {
+  return (
+    <ChatLayout>
+      <div style={{ padding: "24px 0" }}>
+        <Loader size="large" centered />
+      </div>
+    </ChatLayout>
+  );
+}

--- a/frontend/src/components/features/personal/TrainingCard/TrainingCardSkeleton.module.css
+++ b/frontend/src/components/features/personal/TrainingCard/TrainingCardSkeleton.module.css
@@ -9,6 +9,19 @@
   gap: 12px;
 }
 
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.headerActions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
 .tags {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/components/features/personal/TrainingCard/TrainingCardSkeleton.tsx
+++ b/frontend/src/components/features/personal/TrainingCard/TrainingCardSkeleton.tsx
@@ -6,9 +6,26 @@ interface TrainingCardSkeletonProps {
   count?: number;
 }
 
+// 実カード（TrainingCard）と同じ header/tags/content/date の順序にすることで、差し替え時の CLS を抑える
 const SingleCard = () => (
   <div className={styles.card}>
-    <Skeleton variant="text" width="60%" height="16px" />
+    <div className={styles.header}>
+      <Skeleton variant="text" width="60%" height="16px" />
+      <div className={styles.headerActions}>
+        <Skeleton
+          variant="rect"
+          width="16px"
+          height="16px"
+          borderRadius="4px"
+        />
+        <Skeleton
+          variant="rect"
+          width="16px"
+          height="16px"
+          borderRadius="4px"
+        />
+      </div>
+    </div>
     <div className={styles.tags}>
       <Skeleton
         variant="rect"

--- a/frontend/src/components/features/social/SocialPostCard/SocialPostCardSkeleton.module.css
+++ b/frontend/src/components/features/social/SocialPostCard/SocialPostCardSkeleton.module.css
@@ -27,3 +27,17 @@
   flex-direction: column;
   gap: 8px;
 }
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding-top: 8px;
+  border-top: 0.5px solid var(--border-color);
+}

--- a/frontend/src/components/features/social/SocialPostCard/SocialPostCardSkeleton.tsx
+++ b/frontend/src/components/features/social/SocialPostCard/SocialPostCardSkeleton.tsx
@@ -4,23 +4,55 @@ import type { FC } from "react";
 import { Skeleton } from "@/components/shared/Skeleton/Skeleton";
 import styles from "./SocialPostCardSkeleton.module.css";
 
-export const SocialPostCardSkeleton: FC = () => {
+interface SocialPostCardSkeletonProps {
+  /** 表示するスケルトンカードの枚数。viewport を埋められる程度のデフォルト値にしている */
+  count?: number;
+}
+
+// 実カード（SocialPostCard）と同じブロック構成にすることで、差し替え時の CLS を抑える
+const SingleCard = () => (
+  <div className={styles.card} style={{ cursor: "default" }}>
+    <div className={styles.authorHeader}>
+      <Skeleton variant="circle" width="36px" height="36px" />
+      <div className={styles.authorInfo}>
+        <Skeleton variant="text" width="100px" height="14px" />
+        <Skeleton variant="text" width="60px" height="12px" />
+      </div>
+    </div>
+    <div className={styles.content}>
+      <Skeleton variant="text" width="100%" height="14px" />
+      <Skeleton variant="text" width="80%" height="14px" />
+    </div>
+    <div className={styles.tags}>
+      <Skeleton
+        variant="rect"
+        width="52px"
+        height="21px"
+        borderRadius="9999px"
+      />
+      <Skeleton
+        variant="rect"
+        width="40px"
+        height="21px"
+        borderRadius="9999px"
+      />
+    </div>
+    <div className={styles.actions}>
+      <Skeleton variant="rect" width="48px" height="20px" borderRadius="4px" />
+      <Skeleton variant="rect" width="48px" height="20px" borderRadius="4px" />
+      <Skeleton variant="rect" width="24px" height="20px" borderRadius="4px" />
+    </div>
+  </div>
+);
+
+export const SocialPostCardSkeleton: FC<SocialPostCardSkeletonProps> = ({
+  count = 6,
+}) => {
   return (
     <>
-      {[1, 2, 3].map((i) => (
-        <div key={i} className={styles.card} style={{ cursor: "default" }}>
-          <div className={styles.authorHeader}>
-            <Skeleton variant="circle" width="36px" height="36px" />
-            <div className={styles.authorInfo}>
-              <Skeleton variant="text" width="100px" height="14px" />
-              <Skeleton variant="text" width="60px" height="12px" />
-            </div>
-          </div>
-          <div className={styles.content}>
-            <Skeleton variant="text" width="100%" height="14px" />
-            <Skeleton variant="text" width="80%" height="14px" className="" />
-          </div>
-        </div>
+      {Array.from({ length: count }, (_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: スケルトンは静的プレースホルダーで並び替えなし
+        <SingleCard key={i} />
       ))}
     </>
   );

--- a/frontend/src/lib/hooks/useSocialFeed.ts
+++ b/frontend/src/lib/hooks/useSocialFeed.ts
@@ -105,13 +105,15 @@ export function useSocialFeed(tab: SocialTab): UseSocialFeedResult {
       }
     };
 
+    // idle callback のタイムアウトが長すぎるとユーザーがタブをすぐ切替えた際にプリフェッチが間に合わない。
+    // アクティブタブのロードが済んだ直後にバックグラウンド fetch を開始させたいので 1 秒で打ち切る
     if ("requestIdleCallback" in window) {
       const handle = window.requestIdleCallback(prefetchOtherTabs, {
-        timeout: 3000,
+        timeout: 1000,
       });
       return () => window.cancelIdleCallback(handle);
     }
-    const timeoutId = setTimeout(prefetchOtherTabs, 500);
+    const timeoutId = setTimeout(prefetchOtherTabs, 300);
     return () => clearTimeout(timeoutId);
   }, [user?.id, tab, query.isSuccess, queryClient]);
 

--- a/frontend/src/lib/hooks/useTrainingPagesData.ts
+++ b/frontend/src/lib/hooks/useTrainingPagesData.ts
@@ -1,5 +1,6 @@
 import {
   type InfiniteData,
+  keepPreviousData,
   useInfiniteQuery,
   useMutation,
   useQueryClient,
@@ -83,6 +84,9 @@ export function useTrainingPagesData(options: FetchOptions = {}) {
   >({
     queryKey: trainingPagesQueryKey(user?.id, normalizedOptions),
     enabled: !authLoading && !!user?.id,
+    // 検索ワード・タグ・日付レンジ等の filter 変更で queryKey が変わるたびにスケルトンへ戻るのを防ぐため、
+    // 新キー用のデータが取れるまで前のデータを表示（TanStack Query v5 の keepPreviousData 相当）
+    placeholderData: keepPreviousData,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
       if (!user?.id) {

--- a/frontend/src/lib/hooks/useTrainingTags.ts
+++ b/frontend/src/lib/hooks/useTrainingTags.ts
@@ -11,12 +11,23 @@ export interface Tag {
 export const trainingTagsQueryKey = (userId: string | undefined) =>
   ["training-tags", userId] as const;
 
-export function useTrainingTags() {
+interface UseTrainingTagsOptions {
+  /**
+   * タグ取得を有効化するか。デフォルト true。
+   * ページ一覧など、タグフィルタモーダルを開いてから初めてタグを読み込みたい画面では
+   * `{ enabled: isTagModalOpen }` のように絞る。
+   */
+  enabled?: boolean;
+}
+
+export function useTrainingTags({
+  enabled = true,
+}: UseTrainingTagsOptions = {}) {
   const { user } = useAuth();
 
   const query = useQuery<Tag[], Error>({
     queryKey: trainingTagsQueryKey(user?.id),
-    enabled: !!user?.id,
+    enabled: enabled && !!user?.id,
     queryFn: async () => {
       if (!user?.id) return [];
       const response = await getTags(user.id);


### PR DESCRIPTION
## Summary
パフォーマンス改善施策の第 2 弾。稽古ページ一覧・投稿一覧と詳細画面への遷移まわりの UX を重点的にチューニング。

### 変更内容

- **無限スクロールの IntersectionObserver を ref callback パターンへ**（`SocialPostsFeed.tsx`）
  - 旧実装は `useEffect` の依存配列に `[hasMore, isLoadingMore, isLoading]` を持ち、タブ切替やデータ更新のたびに observer が作り直されていた。
  - sentinel の ref callback に切り替え、observer を sentinel マウント時に 1 度だけ生成・破棄するように変更。volatile な値は `useRef` を経由してコールバック内から最新値を参照する形に統一。
- **`useTrainingPagesData` に `placeholderData: keepPreviousData` を導入**
  - 検索ワード / タグ / 日付レンジ / ソート変更で queryKey が切り替わった瞬間にスケルトン UI へ戻るチラつきを防ぎ、フィルタリング体験を滑らかに。
- **`useTrainingTags` を遅延取得に対応**
  - `useTrainingTags({ enabled: boolean })` のオプションを追加。`PersonalPages` 側では `isTagModalOpen` と連動させ、タグフィルタモーダルを開くまで不要な tags fetch を走らせないように。一度取得後はキャッシュから即表示。
- **スケルトン構造を実カードと一致**（`SocialPostCardSkeleton`, `TrainingCardSkeleton`）
  - tags 行 / actions 行 / header のアクションボタンプレースホルダーを追加し、データ差し替え時の CLS（レイアウトシフト）を低減。
  - `SocialPostCardSkeleton` のデフォルト表示数を 3 → 6 に増やし、ビューポート下部の空白を軽減。
- **`useSocialFeed` の他タブプリフェッチ timeout 短縮**
  - `requestIdleCallback` の timeout を 3s → 1s、fallback の `setTimeout` を 500ms → 300ms に。
  - アクティブタブのロード完了直後からバックグラウンド取得を開始させ、ユーザーが素早くタブを切り替えた際でも間に合いやすくする。
- **ページ詳細・投稿詳細に `loading.tsx` を追加**
  - `personal/pages/[page_id]/loading.tsx` → `DefaultLayout` + `TrainingCardSkeleton`
  - `(public)/social/posts/[post_id]/loading.tsx` → `ChatLayout` + Loader
  - リスト → 詳細 への遷移中にヘッダー/フッターが一瞬消えるのを防ぎ、レイアウト連続性を担保。

## Test plan
- [x] `pnpm check`（Biome）が緑
- [x] `pnpm test`（frontend 276 + backend 210 テスト）が緑
- [x] `pnpm tsc --noEmit`（frontend）がエラーなし
- [x] `/ja/personal/pages` で検索ワード入力 / タグ選択 / 日付レンジ変更時にスケルトンへ戻らず、前結果が保たれて滑らかに差し替わる
- [x] `/ja/personal/pages` の初回表示で tags API が呼ばれず、タグフィルタモーダルを初めて開いた時に fetch される（以降はキャッシュから即表示）
- [x] `/ja/social/posts` でタブを高速に切り替えてもスケルトンの後にすぐデータが出る（プリフェッチが効いている）
- [x] 無限スクロールが取りこぼしなく動作する（タブ切替後も）
- [x] ページ一覧 → ページ詳細 / 投稿一覧 → 投稿詳細 の遷移でヘッダー/フッターが保持され、中身だけスケルトンに切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)