### PR TITLE
fix: タグ読み込みとタブ遷移の体感遅延を解消

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
@@ -90,9 +90,10 @@ export function PersonalPages() {
     setIsTagModalOpen,
   } = useTrainingPageModals();
 
-  // タグ一覧はタグフィルタモーダルを開くまで画面に出ないので、初回ロード時の不要フェッチを避けるため遅延取得する。
-  // 一度取得すれば TanStack Query のキャッシュに残るため、2 回目以降のモーダル起動は即時反映される
-  const { availableTags } = useTrainingTags({ enabled: isTagModalOpen });
+  // タグ一覧はモーダルを開いた瞬間に即表示されたほうが体感が良いので、ページマウント時に先取りする。
+  // useTagManagement（ページ作成・投稿作成画面）とも queryKey を共有しており、
+  // /personal/pages → /personal/pages/new への遷移時もキャッシュが効く
+  const { availableTags } = useTrainingTags();
 
   // ソートドロップダウン外クリックで閉じる
   const handleClickOutside = useCallback((event: MouseEvent) => {

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/loading.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/loading.tsx
@@ -1,0 +1,12 @@
+import { TrainingCardSkeleton } from "@/components/features/personal/TrainingCard/TrainingCardSkeleton";
+
+// ページ一覧への遷移中、ヘッダー／タブナビは親 layout が保持し続けるので、
+// loading.tsx 側ではページ本文スケルトンのみ出す（"use client" な Layout を噛ませると
+// SSG 時の static export で createContext 初期化エラーになるため避ける）
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }}>
+      <TrainingCardSkeleton count={4} />
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/loading.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/loading.tsx
@@ -1,0 +1,12 @@
+import { SocialPostCardSkeleton } from "@/components/features/social/SocialPostCard/SocialPostCardSkeleton";
+
+// 投稿一覧への遷移中、ヘッダー／タブナビは親 layout が保持し続けるので、
+// loading.tsx 側ではページ本文スケルトンのみ出す（"use client" な Layout を噛ませると
+// SSG 時の static export で createContext 初期化エラーになるため避ける）
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }}>
+      <SocialPostCardSkeleton count={4} />
+    </div>
+  );
+}

--- a/frontend/src/components/shared/TabNavigation/TabNavigation.module.css
+++ b/frontend/src/components/shared/TabNavigation/TabNavigation.module.css
@@ -18,6 +18,9 @@
   border: none;
   background: var(--white);
   padding: 0;
+  /* Link（<a>）化したので、下線・色継承を button と同じ見た目に揃える */
+  text-decoration: none;
+  color: inherit;
 }
 
 .tab.active {

--- a/frontend/src/components/shared/TabNavigation/TabNavigation.tsx
+++ b/frontend/src/components/shared/TabNavigation/TabNavigation.tsx
@@ -6,54 +6,52 @@ import {
   IdentificationCardIcon,
   PencilSimpleIcon,
 } from "@phosphor-icons/react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import type { FC } from "react";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useUnreadNotificationCount } from "@/lib/hooks/useUnreadNotificationCount";
+import { Link } from "@/lib/i18n/routing";
 import styles from "./TabNavigation.module.css";
 
 interface TabItem {
   id: string;
   label: string;
   icon: Icon;
-  href: string;
+  href: "/personal/pages" | "/social/posts" | "/mypage";
   badge?: number;
 }
-
-// tabsは動的に生成されるようにする
 
 export const TabNavigation: FC = () => {
   const t = useTranslations();
   const locale = useLocale();
-  const router = useRouter();
   const pathname = usePathname();
   const { user } = useAuth();
   const unreadCount = useUnreadNotificationCount(user?.id);
 
+  // next-intl の Link は locale プレフィックスを自動付与するので、href はプレフィックスなしで渡す
   const tabs: TabItem[] = [
     {
       id: "personal",
       label: t("components.personal"),
       icon: PencilSimpleIcon,
-      href: `/${locale}/personal/pages`,
+      href: "/personal/pages",
     },
     {
       id: "social",
       label: t("components.group"),
       icon: ChatsIcon,
-      href: `/${locale}/social/posts`,
+      href: "/social/posts",
       badge: unreadCount,
     },
     {
       id: "mypage",
       label: t("components.mypage"),
       icon: IdentificationCardIcon,
-      href: `/${locale}/mypage`,
+      href: "/mypage",
     },
   ];
 
-  // 現在のパスからアクティブなタブを判定
   const getActiveTab = () => {
     const localePrefix = `/${locale}`;
     const normalizedPath = pathname.startsWith(localePrefix)
@@ -63,28 +61,22 @@ export const TabNavigation: FC = () => {
     if (normalizedPath.startsWith("/personal")) return "personal";
     if (normalizedPath.startsWith("/social")) return "social";
     if (normalizedPath.startsWith("/mypage")) return "mypage";
-    return "personal"; // デフォルト
+    return "personal";
   };
 
   const activeTab = getActiveTab();
-
-  const handleTabChange = (tabId: string) => {
-    const tab = tabs.find((t) => t.id === tabId);
-    if (tab) {
-      router.push(tab.href);
-    }
-  };
 
   return (
     <div className={styles.tabContainer} data-testid="tab-navigation">
       {tabs.map((tab) => {
         const IconComponent = tab.icon;
         return (
-          <button
+          <Link
             key={tab.id}
+            href={tab.href}
+            // next-intl の Link は next/link を内部利用しており、viewport 内の Link は自動で prefetch される。
+            // 常時画面下部に固定されているのでマウント直後から RSC payload が warm になり、タブ切替が即時化される
             className={`${styles.tab} ${activeTab === tab.id ? styles.active : ""}`}
-            onClick={() => handleTabChange(tab.id)}
-            type="button"
           >
             <div className={styles.tabContent}>
               <div className={styles.iconWrapper}>
@@ -99,7 +91,7 @@ export const TabNavigation: FC = () => {
               </div>
               <span className={styles.label}>{tab.label}</span>
             </div>
-          </button>
+          </Link>
         );
       })}
     </div>

--- a/frontend/src/lib/hooks/useTagManagement.test.ts
+++ b/frontend/src/lib/hooks/useTagManagement.test.ts
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // モック定義
@@ -31,6 +33,17 @@ vi.mock("@/lib/api/client", () => ({
 
 import { useTagManagement } from "./useTagManagement";
 
+/** TanStack Query 化に伴い useQuery を使うので、renderHook を QueryClientProvider で包む */
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
 /** 共通のモック初期化 */
 const setupDefaultMocks = () => {
   mockGetCategories.mockResolvedValue({
@@ -61,7 +74,9 @@ describe("useTagManagement", () => {
   describe("タグトグル操作", () => {
     it("未選択のタグをトグルすると選択状態になる", async () => {
       // Arrange
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       // Act
@@ -73,7 +88,9 @@ describe("useTagManagement", () => {
 
     it("選択済みのタグをトグルすると選択解除される", async () => {
       // Arrange
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
       act(() => result.current.handleTagToggle("取り", "立技"));
 
@@ -86,7 +103,9 @@ describe("useTagManagement", () => {
 
     it("複数カテゴリのタグを独立してトグルできる", async () => {
       // Arrange
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       // Act
@@ -104,7 +123,9 @@ describe("useTagManagement", () => {
   describe("新規タグ作成バリデーション", () => {
     it("空文字列の場合はエラートーストを表示しAPIを呼ばない", async () => {
       // Arrange
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
       act(() => result.current.setNewTagInput("   "));
 
@@ -121,7 +142,9 @@ describe("useTagManagement", () => {
 
     it("21文字以上の場合はエラートーストを表示する", async () => {
       // Arrange
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
       act(() => result.current.setNewTagInput("あ".repeat(21)));
 
@@ -138,7 +161,9 @@ describe("useTagManagement", () => {
 
     it("不正な文字（@#$）を含む場合はエラートーストを表示する", async () => {
       // Arrange
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
       act(() => result.current.setNewTagInput("タグ@#$"));
 
@@ -163,7 +188,9 @@ describe("useTagManagement", () => {
           user_id: "user-1",
         },
       });
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
       act(() => result.current.setNewTagInput("半身半立ち"));
 
@@ -191,7 +218,9 @@ describe("useTagManagement", () => {
           sort_order: i,
         })),
       });
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       // Act
@@ -216,7 +245,9 @@ describe("useTagManagement", () => {
           sort_order: 4,
         },
       });
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       // Act
@@ -237,7 +268,9 @@ describe("useTagManagement", () => {
   describe("旧形式互換プロパティ", () => {
     it("tagsByCategoryから取り・受け・技のタグが導出される", async () => {
       // Arrange & Act
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       // Assert
@@ -248,7 +281,9 @@ describe("useTagManagement", () => {
 
     it("setSelectedToriで取りカテゴリの選択状態が更新される", async () => {
       // Arrange
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       // Act
@@ -266,7 +301,9 @@ describe("useTagManagement", () => {
       mockGetTags.mockResolvedValue({ success: true, data: [] });
 
       // Act
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       // Assert
@@ -275,7 +312,9 @@ describe("useTagManagement", () => {
 
     it("タグが1件以上ある場合はneedsInitialTagsがfalseになる", async () => {
       // Arrange & Act
-      const { result } = renderHook(() => useTagManagement());
+      const { result } = renderHook(() => useTagManagement(), {
+        wrapper: createWrapper(),
+      });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       // Assert

--- a/frontend/src/lib/hooks/useTagManagement.ts
+++ b/frontend/src/lib/hooks/useTagManagement.ts
@@ -1,7 +1,8 @@
 "use client";
 
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { TagLanguage } from "@/constants/tags";
 import { MAX_CATEGORIES } from "@/constants/tags";
 import { useToast } from "@/contexts/ToastContext";
@@ -14,12 +15,27 @@ import {
   initializeUserTags,
 } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
+import { trainingTagsQueryKey } from "@/lib/hooks/useTrainingTags";
 import type { UserCategory } from "@/types/category";
+
+/** タグ一覧のキャッシュは useTrainingTags と共有する（queryKey を統一）ので、キーはそちらから再輸出する */
+export { trainingTagsQueryKey };
+
+/** カテゴリ一覧の TanStack Query キャッシュキー */
+export const trainingCategoriesQueryKey = (userId: string | undefined) =>
+  ["training-categories", userId] as const;
 
 interface UseTagManagementOptions {
   /** フックを有効にするか（ページ遷移後に有効化する用途） */
   enabled?: boolean;
 }
+
+type TagEntity = {
+  id: string;
+  name: string;
+  category: string;
+  user_id: string;
+};
 
 export interface UseTagManagementReturn {
   // 動的カテゴリ
@@ -62,13 +78,41 @@ export function useTagManagement(
   const { user } = useAuth();
   const t = useTranslations();
   const { showToast } = useToast();
+  const queryClient = useQueryClient();
 
-  const [allTags, setAllTags] = useState<
-    { id: string; name: string; category: string; user_id: string }[]
-  >([]);
-  const [categories, setCategories] = useState<UserCategory[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [needsInitialTags, setNeedsInitialTags] = useState(false);
+  // カテゴリ / タグは TanStack Query に任せる。
+  // /personal/pages で `useTrainingTags` が事前にタグをキャッシュしていれば、
+  // /personal/pages/new や /social/posts/new に遷移した瞬間にキャッシュヒットする。
+  const categoriesQuery = useQuery<UserCategory[], Error>({
+    queryKey: trainingCategoriesQueryKey(user?.id),
+    enabled: enabled && !!user?.id,
+    queryFn: async () => {
+      if (!user?.id) return [];
+      const response = await getCategories(user.id);
+      if (response?.success && response.data) {
+        return response.data as UserCategory[];
+      }
+      return [];
+    },
+  });
+
+  const tagsQuery = useQuery<TagEntity[], Error>({
+    queryKey: trainingTagsQueryKey(user?.id),
+    enabled: enabled && !!user?.id,
+    queryFn: async () => {
+      if (!user?.id) return [];
+      const response = await getTags(user.id);
+      if (response.success && response.data) {
+        return response.data as TagEntity[];
+      }
+      return [];
+    },
+  });
+
+  const categories = categoriesQuery.data ?? [];
+  const allTags = tagsQuery.data ?? [];
+  const loading = categoriesQuery.isLoading || tagsQuery.isLoading;
+  const needsInitialTags = tagsQuery.isSuccess && allTags.length === 0;
 
   // 動的選択状態: カテゴリ名 → 選択タグ名配列
   const [selectedByCategory, setSelectedByCategoryState] = useState<
@@ -79,64 +123,28 @@ export function useTagManagement(
   const [newTagInput, setNewTagInput] = useState("");
   const [showNewTagInput, setShowNewTagInput] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
-    if (!user?.id || !enabled) return;
-    try {
-      setLoading(true);
-
-      // カテゴリとタグを並列取得
-      const [categoriesResponse, tagsResponse] = await Promise.all([
-        getCategories(user.id),
-        getTags(user.id),
-      ]);
-
-      if (categoriesResponse?.success && categoriesResponse.data) {
-        setCategories(categoriesResponse.data);
-      }
-
-      if (tagsResponse.success && tagsResponse.data) {
-        setAllTags(tagsResponse.data);
-        if (tagsResponse.data.length === 0) {
-          setNeedsInitialTags(true);
-        } else {
-          setNeedsInitialTags(false);
-        }
-      }
-    } catch {
-      // タグ取得失敗は致命的ではない
-    } finally {
-      setLoading(false);
-    }
-  }, [user?.id, enabled]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+  const invalidateTagsAndCategories = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: trainingTagsQueryKey(user?.id),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: trainingCategoriesQueryKey(user?.id),
+      }),
+    ]);
+  }, [queryClient, user?.id]);
 
   const initializeTags = useCallback(
     async (language: TagLanguage) => {
       if (!user?.id) return;
       try {
         await initializeUserTags(user.id, language);
-
-        // 再取得
-        const [categoriesResponse, tagsResponse] = await Promise.all([
-          getCategories(user.id),
-          getTags(user.id),
-        ]);
-
-        if (categoriesResponse?.success && categoriesResponse.data) {
-          setCategories(categoriesResponse.data);
-        }
-        if (tagsResponse.success && tagsResponse.data) {
-          setAllTags(tagsResponse.data);
-          setNeedsInitialTags(false);
-        }
+        await invalidateTagsAndCategories();
       } catch {
         showToast(t("pageModal.tagAddFailed"), "error");
       }
     },
-    [user?.id, showToast, t],
+    [user?.id, showToast, t, invalidateTagsAndCategories],
   );
 
   // タグをカテゴリ別に分類
@@ -207,7 +215,9 @@ export function useTagManagement(
       try {
         const response = await createTag(tagData);
         if (response.success && response.data) {
-          await fetchData();
+          await queryClient.invalidateQueries({
+            queryKey: trainingTagsQueryKey(user?.id),
+          });
           setNewTagInput("");
           setShowNewTagInput(null);
 
@@ -222,7 +232,7 @@ export function useTagManagement(
         );
       }
     },
-    [fetchData, showToast, t, handleTagToggle],
+    [queryClient, user?.id, showToast, t, handleTagToggle],
   );
 
   const handleSubmitNewTag = useCallback(
@@ -273,7 +283,11 @@ export function useTagManagement(
         });
         if (response.success && response.data) {
           const newCat = response.data as UserCategory;
-          setCategories((prev) => [...prev, newCat]);
+          // 即時反映のためキャッシュに追記（サーバー側で作成済みなので invalidate は不要）
+          queryClient.setQueryData<UserCategory[]>(
+            trainingCategoriesQueryKey(user.id),
+            (prev) => (prev ? [...prev, newCat] : [newCat]),
+          );
           showToast(t("tagManagement.categoryCreateSuccess"), "success");
         } else {
           showToast(
@@ -291,7 +305,7 @@ export function useTagManagement(
         );
       }
     },
-    [user?.id, categories.length, showToast, t],
+    [user?.id, categories.length, queryClient, showToast, t],
   );
 
   return {


### PR DESCRIPTION
## Summary
PR #264 / #265 / #266 マージ後にユーザー報告された 3 点の遅延体感を 1 つの修正 PR でまとめて解消。

### 報告された遅延
1. ページ作成 (`/personal/pages/new`) / 投稿作成 (`/social/posts/new`) でタグの読み込みが前より遅い
2. ページ一覧 (`/personal/pages`) のタグフィルタモーダル内のタグ表示が前より遅い
3. 「ひとりで」↔「みんなで」のタブ遷移後の初期読み込みが遅い

### 根本原因
| # | 原因 |
|---|---|
| 1 | `useTagManagement` が **TanStack Query を使わず** 生の `useState + useEffect` で毎回 `getCategories` + `getTags` を直接投げる実装。キャッシュも画面間共有も一切効かず、ページ作成画面を開くたびに 2 本の HTTP 往復が冷状態から走っていた。 |
| 2 | PR2 (M2) で `PersonalPages` の `useTrainingTags` 呼び出しを `{ enabled: isTagModalOpen }` に変え、モーダルを開いた瞬間に fetch を開始する形にしていたため、モーダル内でロードが回る体感になっていた。 |
| 3 | `TabNavigation` が `<button onClick={router.push(href)}>` 実装。Next.js の Link プリフェッチが **一切効かず**、タブを押すたびに毎回 RSC ペイロード取得を冷状態からやり直していた（PR2 の観測最適化や placeholderData はその後段の改善）。 |

### 変更内容

- **`TabNavigation`: `<button>` → `<Link>`**（Issue 3 の最大因）
  - `next-intl` の `<Link>` に置換し、viewport 内 Link の自動プリフェッチを働かせる。
  - 常時画面下部に固定されているので、マウント直後から他タブの RSC が warm になり、タブ切替が即時化する見込み。
  - `TabNavigation.module.css` に `text-decoration: none; color: inherit` を明示。
- **`useTagManagement`: TanStack Query 化**（Issue 1 の主因）
  - カテゴリ取得 / タグ取得を `useQuery` に置換。
  - タグの queryKey は `useTrainingTags` から再輸出した `trainingTagsQueryKey` を **共有** する。これで `/personal/pages` → `/personal/pages/new` / `/social/posts/new` の遷移時にタグキャッシュが即ヒット。
  - mutation は `setQueryData` / `invalidateQueries` でキャッシュ整合。
- **`PersonalPages` の `useTrainingTags` を revert**（Issue 2）
  - `{ enabled: isTagModalOpen }` → `()` に戻し、ページマウント時に先取り fetch する挙動を復活。
  - `useTrainingTags({ enabled })` のオプション自体は他画面での使用に備えて温存。
- **`personal/pages/loading.tsx` / `social/posts/loading.tsx` を追加**（Issue 3 の補助）
  - 初回アクセス時やキャッシュ miss 時に route transition 中の空白を避ける。
  - "use client" な Layout を loading.tsx に取り込むと SSG 時の static export で `createContext` 初期化が失敗するため、ページ本文スケルトンのみに留めた。ヘッダー／タブナビは親 layout が保持するので体感上の違いは小さい。
- **`useTagManagement.test.ts` に `QueryClientProvider` wrapper を追加**
  - `useQuery` 化に伴い `renderHook` に QueryClient を注入する必要があるため。

## Test plan
- [ ] `pnpm check` / `pnpm tsc --noEmit` / `pnpm test`（frontend 276 + backend 210）が緑 *(ローカル確認済み)*
- [ ] `pnpm build` が通る *(ローカル確認済み)*
- [ ] `/ja/personal/pages` のタグフィルタモーダルを開くと、タグが即時表示される
- [ ] `/ja/personal/pages` → FAB で `/ja/personal/pages/new` に遷移、タグが即時表示される（Network タブで `/api/tags` が追加で呼ばれない）
- [ ] `/ja/social/posts` → `/ja/social/posts/new` の「稽古記録」モードでも同様にタグ即時表示
- [ ] bottom tab bar の「ひとりで」「みんなで」「マイページ」をタップしたときの遷移が、明らかに前より速い
- [ ] DevTools で初回 `/ja/personal/pages` ロード時に `/ja/social/posts` の `_rsc` リクエストがプリフェッチされている
- [ ] タグ作成 / カテゴリ作成 / 初期タグ投入が従来通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)