### PR TITLE
chore: 稽古記録ページ一覧と投稿一覧のスケルトン UI を Loader に戻す

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/PersonalPages.tsx
@@ -16,10 +16,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { FilterArea } from "@/components/features/personal/FilterArea/FilterArea";
 import { TagFilterModal } from "@/components/features/personal/TagFilterModal/TagFilterModal";
 import { TrainingCard } from "@/components/features/personal/TrainingCard/TrainingCard";
-import { TrainingCardSkeleton } from "@/components/features/personal/TrainingCard/TrainingCardSkeleton";
 import { Tutorial } from "@/components/features/tutorial/Tutorial";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import { FloatingActionButton } from "@/components/shared/FloatingActionButton/FloatingActionButton";
+import { Loader } from "@/components/shared/Loader";
 import { RefetchErrorBanner } from "@/components/shared/RefetchErrorBanner/RefetchErrorBanner";
 import { Skeleton } from "@/components/shared/Skeleton";
 import { Tooltip } from "@/components/shared/Tooltip/Tooltip";
@@ -301,7 +301,7 @@ export function PersonalPages() {
             <RefetchErrorBanner />
           )}
           {loading ? (
-            <TrainingCardSkeleton count={3} />
+            <Loader size="large" centered />
           ) : displayedTrainingPageData.length === 0 ? (
             hasFiltersApplied ? (
               <p className={styles.emptyMessage}>

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/loading.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/loading.tsx
@@ -1,14 +1,6 @@
-import { TrainingCardSkeleton } from "@/components/features/personal/TrainingCard/TrainingCardSkeleton";
-import { DefaultLayout } from "@/components/shared/layouts/DefaultLayout";
+import { Loader } from "@/components/shared/Loader";
 
-// ページ一覧 → 詳細 への遷移時、Header/Footer を保ったままスケルトンを見せることで
-// 画面が一瞬真っ白になる違和感を抑える
+// ページ詳細への遷移中、他画面と揃えてシンプルな Loader を中央表示する
 export default function Loading() {
-  return (
-    <DefaultLayout>
-      <div style={{ padding: "16px" }}>
-        <TrainingCardSkeleton count={1} />
-      </div>
-    </DefaultLayout>
-  );
+  return <Loader size="large" centered />;
 }

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/loading.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/loading.tsx
@@ -1,12 +1,6 @@
-import { TrainingCardSkeleton } from "@/components/features/personal/TrainingCard/TrainingCardSkeleton";
+import { Loader } from "@/components/shared/Loader";
 
-// ページ一覧への遷移中、ヘッダー／タブナビは親 layout が保持し続けるので、
-// loading.tsx 側ではページ本文スケルトンのみ出す（"use client" な Layout を噛ませると
-// SSG 時の static export で createContext 初期化エラーになるため避ける）
+// ページ一覧への遷移中、他画面（マイページ/編集系）と揃えてシンプルな Loader を中央表示する
 export default function Loading() {
-  return (
-    <div style={{ padding: "16px" }}>
-      <TrainingCardSkeleton count={4} />
-    </div>
-  );
+  return <Loader size="large" centered />;
 }

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/page.test.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/page.test.tsx
@@ -73,14 +73,10 @@ vi.mock("@/components/features/personal/TrainingCard/TrainingCard", () => ({
   ),
 }));
 
-vi.mock(
-  "@/components/features/personal/TrainingCard/TrainingCardSkeleton",
-  () => ({
-    TrainingCardSkeleton: () => (
-      <div data-testid="training-card-skeleton">TrainingCardSkeleton</div>
-    ),
-  }),
-);
+vi.mock("@/components/shared/Loader", () => ({
+  Loader: () => <div data-testid="list-loader">Loader</div>,
+  default: () => <div data-testid="list-loader">Loader</div>,
+}));
 
 vi.mock(
   "@/components/shared/FloatingActionButton/FloatingActionButton",
@@ -314,7 +310,7 @@ describe("ページ一覧画面", () => {
     });
   });
 
-  it("API応答待ちの間にスケルトンが描画される", async () => {
+  it("API応答待ちの間にLoaderが描画される", async () => {
     // Arrange
     mockGetPages.mockImplementation(
       () => new Promise((resolve) => setTimeout(resolve, 1000)),
@@ -330,10 +326,10 @@ describe("ページ一覧画面", () => {
     });
 
     // Assert
-    expect(screen.getByTestId("training-card-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("list-loader")).toBeInTheDocument();
   });
 
-  it("ユーザー情報がnullかつloading中でもクラッシュせずスケルトンが描画される", async () => {
+  it("ユーザー情報がnullかつloading中でもクラッシュせずLoaderが描画される", async () => {
     // Arrange
     mockUseAuth.mockReturnValue({
       user: null,
@@ -361,7 +357,7 @@ describe("ページ一覧画面", () => {
     });
 
     // Assert
-    expect(screen.getByTestId("training-card-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("list-loader")).toBeInTheDocument();
   });
 
   it("ページが0件の場合にTrainingCardが描画されない", async () => {

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/SocialPostsFeed.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/SocialPostsFeed.tsx
@@ -9,7 +9,6 @@ import {
   type SocialFeedPostData,
   SocialPostCard,
 } from "@/components/features/social/SocialPostCard/SocialPostCard";
-import { SocialPostCardSkeleton } from "@/components/features/social/SocialPostCard/SocialPostCardSkeleton";
 import {
   type SocialTab,
   SocialTabBar,
@@ -210,7 +209,7 @@ export function SocialPostsFeed() {
           <RefetchErrorBanner onRetry={refetch} />
         )}
         {isLoading ? (
-          <SocialPostCardSkeleton />
+          <Loader size="large" centered />
         ) : posts.length === 0 ? (
           <p className={styles.emptyMessage}>{t(emptyKey)}</p>
         ) : (

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/loading.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/loading.tsx
@@ -1,12 +1,6 @@
-import { SocialPostCardSkeleton } from "@/components/features/social/SocialPostCard/SocialPostCardSkeleton";
+import { Loader } from "@/components/shared/Loader";
 
-// 投稿一覧への遷移中、ヘッダー／タブナビは親 layout が保持し続けるので、
-// loading.tsx 側ではページ本文スケルトンのみ出す（"use client" な Layout を噛ませると
-// SSG 時の static export で createContext 初期化エラーになるため避ける）
+// 投稿一覧への遷移中、他画面（マイページ/編集系）と揃えてシンプルな Loader を中央表示する
 export default function Loading() {
-  return (
-    <div style={{ padding: "16px" }}>
-      <SocialPostCardSkeleton count={4} />
-    </div>
-  );
+  return <Loader size="large" centered />;
 }


### PR DESCRIPTION
## Summary

稽古記録ページ一覧 (`/personal/pages`) と投稿一覧 (`/social/posts`) のローディング表示を、マイページや編集系の他画面と揃えた Loader ベースの表示に戻す。

## 変更内容

| ファイル | Before | After |
|---|---|---|
| `personal/pages/PersonalPages.tsx` | `<TrainingCardSkeleton count={3} />` | `<Loader size="large" centered />` |
| `social/posts/SocialPostsFeed.tsx` | `<SocialPostCardSkeleton />` | `<Loader size="large" centered />` |
| `personal/pages/loading.tsx` | `<TrainingCardSkeleton count={4} />` | `<Loader size="large" centered />` |
| `social/posts/loading.tsx` | `<SocialPostCardSkeleton count={4} />` | `<Loader size="large" centered />` |
| `personal/pages/[page_id]/loading.tsx` | `<TrainingCardSkeleton count={1} />` | `<Loader size="large" centered />` |
| `personal/pages/page.test.tsx` | `training-card-skeleton` 前提 | `list-loader` モック前提に更新（テスト名とアサーションも調整） |

## 触っていない箇所

- **PersonalPages の件数表示部の小さな `<Skeleton variant="text">`**
  ページ件数 "X 件" のインライン skeleton。Loader（スピナー）にするとインラインで違和感があるため残置。気になれば別途調整可能。
- **ページ作成 (`/personal/pages/new`) / 投稿作成 (`/social/posts/new`)**
  ご依頼の対象に含まれていましたが、現状コードを確認したところ **skeleton も Loader も表示していません**（タグ取得中はタグ枠が空のまま待つ実装）。差し替え対象が存在しないため、今回は変更なし。必要であれば「タグ読み込み中に Loader を出す」対応を別途ご指示ください。
- **`TrainingCardSkeleton` / `SocialPostCardSkeleton` コンポーネント本体**
  削除せず温存。将来また戻したくなった時に即復活できるように。デッドコード整理したい場合は別 PR で。
- **`(public)/social/posts/[post_id]/loading.tsx`**
  既に Loader 使用なので変更なし。

## 既知のトレードオフ

- **CLS が若干悪化する方向**: スケルトンは実カードに近い高さを確保していましたが、Loader は中央スピナーなのでデータ到着時にレイアウトシフトが発生します。Lighthouse / Core Web Vitals の CLS スコアがやや悪化する可能性あり。
- **体感待ち時間がやや長く感じる可能性**: 一般論として「skeleton → content」より「spinner → content」のほうが遅く感じるとされます。ただし PR #268 / #269 でレイテンシ自体が大幅改善済みなので、実用上の影響は小さい見込み。
- **MyPage とは厳密には一致していない点に注意**: MyPage は `UserInfoCardSkeleton` を使用しています。「マイページなどと揃える」というご意向は **Loader 中心に寄せる方針** として解釈し、personal/social 一覧のみ Loader に戻しました。もし MyPage 側も揃えたい場合はお知らせください。

## Test plan
- [x] `pnpm check` / `pnpm tsc --noEmit` / `pnpm test`（frontend 276 + backend 210）が緑
- [ ] `/personal/pages` の初回ロード中にスピナーが中央表示されること
- [ ] `/social/posts` の初回ロード中・タブ切替中にスピナーが中央表示されること
- [ ] ページ一覧 → ページ詳細 の遷移中にもスピナーが表示されること
- [ ] マイページの表示は従来通り `UserInfoCardSkeleton` のまま変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)