### PR TITLE
fix: ネイティブアプリの認証 Cookie を永続化して再ログイン頻度を低減

### DIFF
--- a/frontend/src/app/api/auth/native-session/route.ts
+++ b/frontend/src/app/api/auth/native-session/route.ts
@@ -32,6 +32,12 @@ export async function POST(request: NextRequest) {
   // レスポンスに Cookie をセットするため、response を先に作成
   const response = NextResponse.json({ success: true });
 
+  // ネイティブアプリ (WebView) で kill 後も認証を維持できるよう、Supabase SSR が
+  // セットする Cookie に明示的な永続化属性を付与する。Supabase デフォルトでは
+  // maxAge が省略されるケースがあり、その場合 WebView は session cookie として
+  // 扱ってアプリ終了時に消去するため、1 日に数回再ログインが必要になる症状が出る。
+  const PERSISTENT_COOKIE_MAX_AGE = 60 * 60 * 24 * 60; // 60日 (refresh token 寿命に合わせる)
+
   const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
     cookies: {
       getAll() {
@@ -45,7 +51,15 @@ export async function POST(request: NextRequest) {
         }[],
       ) {
         cookiesToSet.forEach(({ name, value, options }) => {
-          response.cookies.set({ name, value, ...options });
+          response.cookies.set({
+            name,
+            value,
+            ...options,
+            maxAge: options.maxAge ?? PERSISTENT_COOKIE_MAX_AGE,
+            sameSite: options.sameSite ?? "lax",
+            httpOnly: options.httpOnly ?? true,
+            path: options.path ?? "/",
+          });
         });
       },
     },


### PR DESCRIPTION
## Summary

- ネイティブアプリ (iOS / Android) ユーザーから「1 日に数回再ログインを求められる」報告に対する第一弾の対応
- `/api/auth/native-session` が発行する Supabase 認証 Cookie に `maxAge` を明示的に指定し、WebView がセッション Cookie 扱いしてアプリ kill 時に消去してしまう挙動を防ぐ
- `maxAge` は refresh token 寿命と同じ **60 日** に設定

## 背景・原因仮説

ネイティブアプリは Web 版の Supabase Auth を WebView の Cookie 共有 (`sharedCookiesEnabled` / `thirdPartyCookiesEnabled`) で永続化する設計。Web 版では同じ端末・ブラウザなら永続的にログイン状態が維持されるが、ネイティブでは「1 日に数回再ログインが必要」というユーザー報告があった。

調査の結果、`/api/auth/native-session` の Cookie 設定で **`maxAge` が明示されておらず**、Supabase SSR が返した options をそのまま使っていた。Supabase デフォルトでは `maxAge` が省略されるケースがあり、その場合 WebView は **session cookie** として扱う。WebView は通常アプリ kill 時に session cookie を破棄するため、access token (1 時間) と refresh token (30 日) の両方を失い、結果として再ログインが必要になっていた可能性が高い。

## 変更内容

`frontend/src/app/api/auth/native-session/route.ts` の `setAll` で Supabase が指定する options をフォールバックとして尊重しつつ、未指定の場合は以下を補完:

- `maxAge`: 60 日 (refresh token 寿命相当)
- `sameSite`: `lax`
- `httpOnly`: `true`
- `path`: `/`

`secure` 属性は Supabase デフォルト (本番環境で `true`) に委ねる。

## 影響範囲

- ネイティブアプリ経由の OAuth (Google / Apple) ログインで設定される Cookie のみ
- Web ブラウザ経由のログインフロー (`signInWithCredentials` 等) には影響なし
- 既存ログイン状態のユーザーは、次回 OAuth 再ログイン時に新しい Cookie 属性が適用される

## 残課題（次の対応候補）

- Email/Password ログイン経路 (`useAuth.tsx` の `signInWithCredentials`) でも同じ症状が出るかユーザーフィードバック確認
- リリース後 1〜2 週間程度の本番計測で「再ログイン頻度」の改善を確認
- ネイティブ起動時に Cookie 有無をログ送信するテレメトリの追加検討

## Test plan

- [x] Vercel Preview で `/api/auth/native-session` の response Cookie に `Max-Age=5184000` (60 日) が付与されることを確認
- [x] ネイティブアプリ (Development Build) で OAuth ログイン → アプリ完全終了 → 再起動でログイン状態が維持されることを確認 (iOS / Android 両方)
- [x] 既存テストがすべてパス (CI で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)