### PR TITLE
fix: ページ・投稿作成直後に一覧へ反映されない問題を invalidateQueries で解消

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/new/PageCreate.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/new/PageCreate.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ClipboardText, PlusCircle } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -37,6 +38,7 @@ export function PageCreate() {
   const searchParams = useSearchParams();
   const titleInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const returnUrl = searchParams.get("returnUrl") || "/personal/pages";
   const dateParam = searchParams.get("date");
@@ -176,6 +178,12 @@ export function PageCreate() {
           console.warn("稽古参加の自動登録に失敗:", err);
         }
 
+        // 一覧画面 (useTrainingPagesData) のキャッシュを無効化して、
+        // 遷移先で作成したばかりのページが反映されるようにする。
+        // staleTime に関係なく強制 refetch されるため、staleTime 延長による
+        // 表示遅延（PR #273）の回帰を防ぐ。
+        queryClient.invalidateQueries({ queryKey: ["training-pages"] });
+
         isNavigatingRef.current = true;
         router.replace(returnUrl);
       } else {
@@ -208,6 +216,7 @@ export function PageCreate() {
     returnUrl,
     dateParam,
     router,
+    queryClient,
   ]);
 
   const handleBack = useCallback(() => {

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/new/SocialPostCreate.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/new/SocialPostCreate.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ClipboardText, PlusCircle } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
@@ -44,6 +45,7 @@ export function SocialPostCreate() {
   const tSocial = useTranslations("socialPosts");
   const { showToast } = useToast();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const modeGroupId = useId();
   const titleInputRef = useRef<HTMLInputElement>(null);
   const postTextareaRef = useRef<HTMLTextAreaElement>(null);
@@ -182,6 +184,11 @@ export function SocialPostCreate() {
         incrementPostCount();
         const postId = (result.data as { id: string }).id;
         await postAttachmentMgmt.saveNewAttachments(postId);
+
+        // 投稿一覧 (useSocialFeed) のキャッシュを無効化して、遷移先で
+        // 作成したばかりの投稿が反映されるようにする。staleTime に関係なく
+        // 強制 refetch されるため、staleTime 延長による表示遅延を防ぐ。
+        queryClient.invalidateQueries({ queryKey: ["social-feed"] });
       }
 
       if (result.success && result.warning) {
@@ -207,6 +214,7 @@ export function SocialPostCreate() {
     showToast,
     tSocial,
     router,
+    queryClient,
   ]);
 
   // 稽古記録モード送信
@@ -246,6 +254,11 @@ export function SocialPostCreate() {
           console.warn("稽古参加の自動登録に失敗:", err);
         }
 
+        // 稽古記録モードは is_public=true でページ + 連動 SocialPost を作成するため、
+        // ページ一覧と投稿一覧の両キャッシュを無効化する。
+        queryClient.invalidateQueries({ queryKey: ["training-pages"] });
+        queryClient.invalidateQueries({ queryKey: ["social-feed"] });
+
         isNavigatingRef.current = true;
         router.replace("/social/posts");
       } else {
@@ -272,6 +285,7 @@ export function SocialPostCreate() {
     showToast,
     tSocial,
     router,
+    queryClient,
   ]);
 
   const handleAddCategory = async () => {


### PR DESCRIPTION
## Summary

PR #273 で TanStack Query の \`staleTime\` を 30秒 → 2分に延長した結果、新規にページや投稿を作成した直後、一覧画面に遷移しても作成済みデータが表示されない問題が発生していた。`invalidateQueries` を追加して反映漏れを解消する。

## 原因

\`PageCreate.tsx\` / \`SocialPostCreate.tsx\` は \`useMutation\` を介さず \`createPage\` / \`createSocialPost\` を直接呼ぶ実装で、**mutation 後に \`invalidateQueries\` を呼んでいなかった**。

このため一覧画面に遷移しても \`useTrainingPagesData\` / \`useSocialFeed\` の \`useInfiniteQuery\` が **キャッシュを fresh と判断してそのまま返す** ため、新規作成データが画面に出てこなかった（\`useTrainingPagesData\` の削除 mutation はもともと invalidate を呼んでいるが、作成は別ファイルで実装されていたため抜けていた）。

## なぜ \`invalidateQueries\` で解消できるのか（PR #273 の意図を壊さない理由）

\`invalidateQueries\` は **\`staleTime\` の値を一切無視** して強制的に refetch を発火する API。

- 同一画面の再表示・タブ往復のキャッシュヒットによる高速化（PR #273 の本旨）→ **そのまま維持**
- 作成直後の一覧反映 → **必ず最新データを取りに行く**

の両立ができる。staleTime を緩める方向（30秒に戻す等）の対処ではなく、ピンポイントで該当 mutation 後の整合性だけを取る形。

## 変更内容

### \`PageCreate.tsx\`
- \`useQueryClient\` を import + \`queryClient\` を取得
- \`handleSubmit\` の \`result.success\` 分岐内で \`queryClient.invalidateQueries({ queryKey: ["training-pages"] })\`
- \`handleSubmit\` の \`useCallback\` deps に \`queryClient\` 追加（Biome \`useExhaustiveDependencies\` 対応）

### \`SocialPostCreate.tsx\`
- \`useQueryClient\` を import + \`queryClient\` を取得
- \`handlePostSubmit\`（投稿モード）成功時: \`queryClient.invalidateQueries({ queryKey: ["social-feed"] })\`
- \`handleTrainingSubmit\`（稽古記録モード）成功時: \`["training-pages"]\` と \`["social-feed"]\` の両方を invalidate
  - 稽古記録モードは \`is_public=true\` でページ作成 + 連動 SocialPost 作成が走るため、両方の一覧キャッシュを更新する必要がある
- 各 \`useCallback\` deps に \`queryClient\` 追加

## 体感の流れ（修正後）

1. 「作成」ボタン押下 → サーバーで作成成功
2. \`invalidateQueries\` 発火 → 該当 queryKey が stale 化 + 即座に refetch 開始
3. \`router.replace('/personal/pages')\` で一覧画面に遷移
4. 一覧画面の \`useInfiniteQuery\` は **stale 状態のキャッシュ** ＋ **進行中の refetch** を見るので、キャッシュ即表示しつつ裏で最新データに置き換え
5. 数百 ms 以内に新規データを含む一覧が表示される

完全な楽観的更新（\`setQueryData\` で先頭にすぐ差し込む）まではやっていないので、「キャッシュの古い一覧が一瞬見えてから最新に置き換わる」挙動は残る。これが気になる場合は次のステップで楽観的更新を入れられる。

## テスト

- TypeScript 型チェック: pass
- Biome lint: 既存 warnings 9 件のみ、新規エラーなし
- frontend テスト: **276/276 件 pass**

## 関連

- 元の最適化 PR: #273
- このリグレッション修正コミットは元 \`perf/network-optimizations\` ブランチに 1 度乗せたが、PR #273 が merged 済みのため本 PR で出し直し（同一コミット内容）
- 元ブランチは別途整理予定

## Test plan

- [ ] Vercel Preview にて、ページ作成 → \`/personal/pages\` 遷移直後に新規ページが先頭表示
- [ ] 投稿作成（投稿モード）→ \`/social/posts\` 遷移直後に新規投稿が先頭表示
- [ ] 稽古記録モード → \`/social/posts\` で新規投稿表示 + \`/personal/pages\` でも新規ページ表示
- [ ] 同一画面の再表示・タブ往復の高速化（PR #273 の効果）が損なわれていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)