### PR TITLE
fix(ppr): restore segment Loader to cover full-screen rerender on Web

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/loading.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/loading.tsx
@@ -1,6 +1,9 @@
-// segment loading.tsx は page 内の <Suspense fallback> より外側で動くため、ここで
-// 何かを返すと page ごとに用意した専用 Skeleton が上書きされてしまう。null を返して
-// page level の fallback に委ねる
+import { Loader } from "@/components/shared/Loader";
+
+// page.tsx 解決前の「何も表示されない時間」を埋める。page 解決後は内側の
+// <Suspense fallback={<XxxSkeleton />}> が引き継ぐ二段構成。
+// 共通 layout で Header / Footer を共有していないため Web 版では navigation 時に
+// 全体再描画が起きるが、その間に Loader を出すことでチラつきの体感を抑える。
 export default function AuthenticatedLoading() {
-  return null;
+  return <Loader size="large" centered />;
 }

--- a/frontend/src/app/[locale]/(public)/loading.tsx
+++ b/frontend/src/app/[locale]/(public)/loading.tsx
@@ -1,6 +1,7 @@
-// segment loading.tsx は page 内の <Suspense fallback> より外側で動くため、ここで
-// 何かを返すと page ごとに用意した専用 Skeleton が上書きされてしまう。null を返して
-// page level の fallback に委ねる
+import { Loader } from "@/components/shared/Loader";
+
+// page.tsx 解決前の「何も表示されない時間」を埋める。page 解決後は内側の
+// <Suspense fallback={<XxxSkeleton />}> が引き継ぐ二段構成。
 export default function PublicLoading() {
-  return null;
+  return <Loader size="large" centered />;
 }


### PR DESCRIPTION
## Summary

PR #275 で `(authenticated)/loading.tsx` と `(public)/loading.tsx` を null 返却にしていたが、Web 版の throttling 環境で **タブ切替時に画面全体が再描画される過渡期に 0.5〜1 秒の「何も表示されない時間」が発生する**問題が実機検証で判明。中央 Loader を復元して体感のチラつきを抑える応急修正。

スマホアプリの WebView では next-intl Link の prefetch がよく効くため Skeleton が即時表示されており、Web 版の方だけ問題が顕在化していた。

## なぜ画面全体再描画が起きるか

`(authenticated)/layout.tsx` を passthrough にした関係で、Header / TabNavigation を含む `DefaultLayout` / `SocialLayout` 風 DOM が各 page.tsx の中に閉じ込められている。Next.js app router の layout システムでは「親 layout は再 render されず page だけ差し替わる」が、各 page で個別 render している現状の構造ではこのメリットを享受できず、navigation のたびに Header / Footer まで含めて全体が新規生成される。

## なぜ本質的解決ではなく Loader 復元か

本質的解決は `(authenticated)/layout.tsx` で共通 Header / TabNavigation を保持し、各 page は main の中身だけ render する構造変更。ただし機能領域ごとに `DefaultLayout` / `MinimalLayout` / `SocialLayout` 風 inline と layout 種別が分かれているため、共通化には大規模リファクタが必要で別 PR で対応したい。

## 挙動（二段構成）

1. **page.tsx 解決前**: segment loading.tsx の `<Loader />` を表示
2. **page 解決後 AuthGate / データ fetch 中**: page 内の `<Suspense fallback>` の専用 Skeleton (`SocialPostsFeedSkeleton` / `MyPageSkeleton` 等) を表示
3. **データ取得完了**: 実コンテンツを表示

スマホアプリでは prefetch が効いて 1 を素通りすることが多く、Skeleton が visible になる挙動は維持される。Web 版でも navigation が高速なら同様。

## Test plan

- [x] `pnpm check` / `pnpm tsc --noEmit` / `pnpm test` (276/276) / `pnpm build` すべて PASS
- [x] 全 37 page route の `◐ Partial Prerender` 化を維持
- [ ] dev で throttling 有効 → タブ切替時に「何も表示されない時間」がなくなり Loader → データ表示の流れになる
- [ ] スマホアプリ (WebView) で従来通り Skeleton が即時表示される挙動が維持される

## 残課題（別 PR 推奨）

- `(authenticated)/layout.tsx` で共通 Header / TabNavigation を持つ layout 構造への移行
- これにより navigation 時の全体再描画が消え Skeleton が即時表示される本質的解決が可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)