### PR TITLE
fix(auth): force account selection on Google/Apple OAuth via prompt=select_account

### DIFF
--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -90,8 +90,17 @@ export async function GET(request: NextRequest) {
         ? decodeURIComponent(returnToCookie)
         : null;
 
+      // 認証フロー内 path (signup/login/verify-email/forgot-password/reset-password) への
+      // 戻りループを防ぐ。10 分以内の setReturnTo 残存などで誤って戻されると新規登録画面で
+      // 滞留してしまうため、これらは無視して /personal/pages にフォールバックする
+      const isAuthPath = returnToPath
+        ? /^\/(?:[a-z]{2}\/)?(signup|login|verify-email|forgot-password|reset-password)(\/|$|\?)/.test(
+            returnToPath,
+          )
+        : false;
+
       let response: NextResponse;
-      if (returnToPath && isValidReturnTo(returnToPath)) {
+      if (returnToPath && isValidReturnTo(returnToPath) && !isAuthPath) {
         response = NextResponse.redirect(new URL(returnToPath, redirectOrigin));
       } else {
         response = NextResponse.redirect(buildUrl("/personal/pages"));

--- a/frontend/src/lib/hooks/useAuth.tsx
+++ b/frontend/src/lib/hooks/useAuth.tsx
@@ -345,6 +345,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         provider: "google",
         options: {
           redirectTo: getRedirectUrl("/auth/callback"),
+          // 既存の Google セッションでサイレント認証されないよう、毎回アカウント選択を強制
+          queryParams: { prompt: "select_account" },
         },
       });
 
@@ -401,6 +403,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         provider: "apple",
         options: {
           redirectTo: getRedirectUrl("/auth/callback"),
+          // 既存の Apple セッションでサイレント認証されないよう、毎回アカウント選択を強制
+          queryParams: { prompt: "select_account" },
         },
       });
 


### PR DESCRIPTION
## Summary

Google OAuth サインインで「アカウント選択画面が出ず前回のアカウントで自動ログインされる」「アカウント選択後に新規登録画面に戻される」問題を修正。Supabase 経由の `signInWithOAuth` 呼び出しに `prompt=select_account` が指定されていなかったことが主因で、Google が既存セッションでサイレント認証する挙動になっていました。

## 症状

ユーザーから:
- **症状 A**: アカウント選択後にアプリのスプラッシュ画面に戻り、新規登録画面に戻される
- **症状 B**: アカウント選択画面に到達せず、前回のアカウントで自動ログイン → 別アカウントへ切替不可
- メールアドレス認証は正常

## 主因と修正

### 主因（症状 B）

`frontend/src/lib/hooks/useAuth.tsx` の `signInWithGoogle` / `signInWithApple` で `supabase.auth.signInWithOAuth` を呼ぶ際 `options.queryParams` が指定されていない:

```ts
// Before
await supabase.auth.signInWithOAuth({
  provider: "google",
  options: { redirectTo: getRedirectUrl("/auth/callback") },
});

// After
await supabase.auth.signInWithOAuth({
  provider: "google",
  options: {
    redirectTo: getRedirectUrl("/auth/callback"),
    queryParams: { prompt: "select_account" },
  },
});
```

`prompt=select_account` を渡さないと Google は **ブラウザに残っている既存の Google セッションでサイレント認証を試みる**仕様で、アカウント選択画面がスキップされる。

### 補助修正（症状 A の保険）

`frontend/src/app/auth/callback/route.ts` の returnTo redirect に「auth 系 path への戻りはフォールバック」のチェックを追加。`auth_return_to` cookie の max-age 10 分以内に `setReturnTo("/signup")` が踏まれていた場合などのループを防ぐ。

```ts
const isAuthPath = returnToPath
  ? /^\/(?:[a-z]{2}\/)?(signup|login|verify-email|forgot-password|reset-password)(\/|$|\?)/.test(returnToPath)
  : false;

if (returnToPath && isValidReturnTo(returnToPath) && !isAuthPath) {
  // ...returnToPath へ
} else {
  // /personal/pages へフォールバック
}
```

## ネイティブアプリ側の挙動

iOS/Android アプリ (`__AIKINOTE_NATIVE_APP__` フラグ立ち) では `useAuth.tsx:316-338` で `startNativeOAuth` ブリッジ経由で外部ブラウザに OAuth を委譲する経路に分岐するため、**この経路は本 PR の `signInWithOAuth` 修正は通りません**。ネイティブ側 OAuth URL での `prompt=select_account` 指定は `aikinote-native-app` 側で別途対応が必要です。

ただし WebView で AikiNote Web 版を直接表示している場合 (= フラグが立っていない通常 WebView) は本修正で改善します。

## Test plan

- [x] `pnpm check` / `pnpm tsc --noEmit` / `pnpm test` (276/276) / `pnpm build` すべて PASS
- [x] 全 37 page route の `◐ Partial Prerender` 化を維持
- [ ] dev で `/signup` → 「Googleではじめる」押下 → **アカウント選択画面が必ず表示される**
- [ ] サインアウト後、再度 `/login` → 「Googleでログイン」押下 → 同じく選択画面が表示される
- [ ] 別の Google アカウントを選択 → AikiNote にログイン成功し `/personal/pages` 表示
- [ ] メールアドレス認証は引き続き正常動作
- [ ] 正規の returnTo (例: `/personal/pages/[id]`) への遷移が引き続き動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)