### PR TITLE
fix: NGワード検出時に投稿/返信を拒否するよう変更（Apple Guideline 1.2 対応）

### DIFF
--- a/backend/src/routes/social-posts/index.ts
+++ b/backend/src/routes/social-posts/index.ts
@@ -249,10 +249,18 @@ app.post(
         );
       }
 
-      // NGワードチェック（ブロックせず警告のみ）
+      // NGワードチェック（拒否）
       if (ngResult.found) {
         console.warn(
           `[NGワード検出] 投稿作成 userId=${input.user_id} matchedWord="${ngResult.matchedWord}"`,
+        );
+        return c.json(
+          {
+            success: false,
+            error: "不適切な表現が含まれているため投稿できません",
+            code: "NG_WORD",
+          },
+          400,
         );
       }
 
@@ -309,10 +317,6 @@ app.post(
           success: true,
           data: post,
           message: "投稿を作成しました",
-          ...(ngResult.found && {
-            warning:
-              "不適切な表現が含まれている可能性があります。内容を修正してください。",
-          }),
         },
         201,
       );
@@ -458,15 +462,21 @@ app.put(
         );
       }
 
-      // NGワードチェック（ブロックせず警告のみ）
-      let ngWarning = false;
+      // NGワードチェック（拒否）
       if (input.content) {
         const ngResult = await containsNgWord(input.content, supabase);
         if (ngResult.found) {
           console.warn(
             `[NGワード検出] 投稿更新 userId=${userId} postId=${postId} matchedWord="${ngResult.matchedWord}"`,
           );
-          ngWarning = true;
+          return c.json(
+            {
+              success: false,
+              error: "不適切な表現が含まれているため更新できません",
+              code: "NG_WORD",
+            },
+            400,
+          );
         }
       }
 
@@ -498,10 +508,6 @@ app.put(
         success: true,
         data: post,
         message: "投稿を更新しました",
-        ...(ngWarning && {
-          warning:
-            "不適切な表現が含まれている可能性があります。内容を修正してください。",
-        }),
       });
     } catch (error) {
       console.error("投稿更新エラー:", error);
@@ -618,12 +624,19 @@ app.post(
         );
       }
 
-      // NGワードチェック
-      // NGワードチェック（ブロックせず警告のみ）
+      // NGワードチェック（拒否）
       const ngResult = await containsNgWord(input.content, supabase);
       if (ngResult.found) {
         console.warn(
           `[NGワード検出] 返信作成 userId=${userId} postId=${postId} matchedWord="${ngResult.matchedWord}"`,
+        );
+        return c.json(
+          {
+            success: false,
+            error: "不適切な表現が含まれているため返信できません",
+            code: "NG_WORD",
+          },
+          400,
         );
       }
 
@@ -682,10 +695,6 @@ app.post(
           success: true,
           data: reply,
           message: "返信を作成しました",
-          ...(ngResult.found && {
-            warning:
-              "不適切な表現が含まれている可能性があります。内容を修正してください。",
-          }),
         },
         201,
       );
@@ -724,11 +733,19 @@ app.put(
         );
       }
 
-      // NGワードチェック（ブロックせず警告のみ）
+      // NGワードチェック（拒否）
       const ngResult = await containsNgWord(input.content, supabase);
       if (ngResult.found) {
         console.warn(
           `[NGワード検出] 返信更新 userId=${userId} replyId=${replyId} matchedWord="${ngResult.matchedWord}"`,
+        );
+        return c.json(
+          {
+            success: false,
+            error: "不適切な表現が含まれているため更新できません",
+            code: "NG_WORD",
+          },
+          400,
         );
       }
 
@@ -740,10 +757,6 @@ app.put(
         success: true,
         data: reply,
         message: "返信を更新しました",
-        ...(ngResult.found && {
-          warning:
-            "不適切な表現が含まれている可能性があります。内容を修正してください。",
-        }),
       });
     } catch (error) {
       console.error("返信更新エラー:", error);

--- a/backend/src/routes/social-posts/index.ts
+++ b/backend/src/routes/social-posts/index.ts
@@ -257,8 +257,9 @@ app.post(
         return c.json(
           {
             success: false,
-            error: "不適切な表現が含まれているため投稿できません",
+            error: `不適切な表現「${ngResult.matchedWord}」が含まれているため投稿できません`,
             code: "NG_WORD",
+            matched_word: ngResult.matchedWord,
           },
           400,
         );
@@ -472,8 +473,9 @@ app.put(
           return c.json(
             {
               success: false,
-              error: "不適切な表現が含まれているため更新できません",
+              error: `不適切な表現「${ngResult.matchedWord}」が含まれているため更新できません`,
               code: "NG_WORD",
+              matched_word: ngResult.matchedWord,
             },
             400,
           );
@@ -633,8 +635,9 @@ app.post(
         return c.json(
           {
             success: false,
-            error: "不適切な表現が含まれているため返信できません",
+            error: `不適切な表現「${ngResult.matchedWord}」が含まれているため返信できません`,
             code: "NG_WORD",
+            matched_word: ngResult.matchedWord,
           },
           400,
         );
@@ -742,8 +745,9 @@ app.put(
         return c.json(
           {
             success: false,
-            error: "不適切な表現が含まれているため更新できません",
+            error: `不適切な表現「${ngResult.matchedWord}」が含まれているため更新できません`,
             code: "NG_WORD",
+            matched_word: ngResult.matchedWord,
           },
           400,
         );

--- a/backend/src/routes/social-posts/social-posts.test.ts
+++ b/backend/src/routes/social-posts/social-posts.test.ts
@@ -260,18 +260,12 @@ describe("投稿作成 POST /api/social-posts", () => {
     expect(res.status).toBe(429);
   });
 
-  it("NGワードが検出された場合は投稿は成功するがwarningが返る", async () => {
+  it("NGワードが検出された場合は投稿が拒否される (400 + NG_WORD)", async () => {
     // Arrange
     mockContainsNgWord.mockResolvedValue({
       found: true,
       matchedWord: "禁止語",
     });
-    const mockPost = {
-      id: "post-1",
-      content: "テスト",
-      user_id: TEST_USER_ID,
-    };
-    mockCreateSocialPost.mockResolvedValue(mockPost);
     const app = createTestApp();
     const headers = await createAuthHeaders();
 
@@ -287,10 +281,11 @@ describe("投稿作成 POST /api/social-posts", () => {
     });
     const body = await res.json();
 
-    // Assert: 投稿は成功（201）、warningフィールドが存在
-    expect(res.status).toBe(201);
-    expect(body.success).toBe(true);
-    expect(body.warning).toBeDefined();
+    // Assert: 投稿は拒否（400）、code: "NG_WORD"、createSocialPost は呼ばれない
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("NG_WORD");
+    expect(mockCreateSocialPost).not.toHaveBeenCalled();
   });
 
   it("ハッシュタグを含む投稿でupsertHashtagsが呼ばれる", async () => {

--- a/backend/src/routes/social-posts/social-posts.test.ts
+++ b/backend/src/routes/social-posts/social-posts.test.ts
@@ -281,10 +281,12 @@ describe("投稿作成 POST /api/social-posts", () => {
     });
     const body = await res.json();
 
-    // Assert: 投稿は拒否（400）、code: "NG_WORD"、createSocialPost は呼ばれない
+    // Assert: 投稿は拒否（400）、code + matched_word が返り、error 文言にも反映、createSocialPost は呼ばれない
     expect(res.status).toBe(400);
     expect(body.success).toBe(false);
     expect(body.code).toBe("NG_WORD");
+    expect(body.matched_word).toBe("禁止語");
+    expect(body.error).toContain("禁止語");
     expect(mockCreateSocialPost).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Apple App Review Guideline 1.2 (User-Generated Content) で要求される「objectionable content フィルタ」要件への対応として、NGワード検出時の挙動を **「警告のみ」→「400 拒否」** に変更しました。

これは Apple iOS 版審査リジェクト対応プランの **Phase 1 (PR-1)** に該当する変更です。

## 変更内容

`backend/src/routes/social-posts/index.ts` の以下 4 箇所で同じ変更を実施:

- 投稿作成 (POST `/api/social-posts`)
- 投稿更新 (PUT `/api/social-posts/:id`)
- 返信作成 (POST `/api/social-posts/:id/replies`)
- 返信更新 (PUT `/api/social-posts/:id/replies/:replyId`)

### Before
```ts
if (ngResult.found) console.warn(...);
// その後 createSocialPost を実行
return c.json({ success: true, ..., warning: "..." }, 201);
```

### After
```ts
if (ngResult.found) {
  console.warn(...);
  return c.json({
    success: false,
    error: "不適切な表現が含まれているため投稿できません",
    code: "NG_WORD",
  }, 400);
}
// 以降の作成処理に到達しない
```

`code: "NG_WORD"` は将来 frontend で個別ハンドリングする際の分岐用に付与しています。今回は frontend 側は既存の error 文言表示メカニズムにそのまま乗るため変更なし（backend が返す日本語 error 文言が toast に出る）。

## NG ワードリスト

`NgWord` テーブルの seed (002 マイグレーション) に英日両方の典型語が入っており追加不要。新規追加が必要な場合は別途 seed マイグレーションを切ります。

## Test plan

- [x] `pnpm vitest run src/routes/social-posts/social-posts.test.ts` 既存 10 テストすべてグリーン（NGワード警告系のテストは拒否系へ書き換え済み）
- [x] `tsc --noEmit` 通過
- [x] pre-commit フック (`pnpm -r check` + `tsc --noEmit` 両パッケージ) 通過
- [x] Vercel preview デプロイで投稿フォームに NG ワードを入力 → 400 エラーで投稿失敗を確認
- [x] 既存の正常投稿が引き続き作成可能であること
- [x] スクリーン録画用に「NGワード入力 → エラートースト」を撮影（Apple 再申請時の Reviewer Notes に添付）

## Related

Apple App Review リジェクト対応プラン全体の Phase 1。後続フェーズ:
- Phase 2: 投稿カードに通報導線追加
- Phase 3: ユーザーブロック機能
- Phase 4: 通報の運営 Slack/Email 通知
- Phase 5: iOS 再ビルド & 再提出

🤖 Generated with [Claude Code](https://claude.com/claude-code)