### PR TITLE
feat: 投稿カードに通報導線を追加（Apple Guideline 1.2 対応）

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/(tabbed)/social/posts/SocialPostsFeed.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/(tabbed)/social/posts/SocialPostsFeed.tsx
@@ -19,6 +19,7 @@ import { PremiumUpgradeModal } from "@/components/shared/PremiumUpgradeModal/Pre
 import { PublicityConfirmDialog } from "@/components/shared/PublicityConfirmDialog/PublicityConfirmDialog";
 import { RefetchErrorBanner } from "@/components/shared/RefetchErrorBanner/RefetchErrorBanner";
 import { useToast } from "@/contexts/ToastContext";
+import { reportPost } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useDailyLimits } from "@/lib/hooks/useDailyLimits";
 import { useSocialFavorite } from "@/lib/hooks/useSocialFavorite";
@@ -158,6 +159,28 @@ export function SocialPostsFeed() {
     [router],
   );
 
+  const handlePostReport = useCallback(
+    async (
+      postId: string,
+      reason:
+        | "spam"
+        | "harassment"
+        | "inappropriate"
+        | "impersonation"
+        | "other",
+      detail?: string,
+    ) => {
+      if (!user?.id) return;
+      try {
+        await reportPost({ postId, user_id: user.id, reason, detail });
+        showToast(t("reportSuccess"), "success");
+      } catch {
+        showToast(t("reportFailed"), "error");
+      }
+    },
+    [user?.id, showToast, t],
+  );
+
   const emptyKey =
     activeTab === "all"
       ? "emptyAll"
@@ -222,6 +245,7 @@ export function SocialPostsFeed() {
                 hasUnreadReplies={unreadReplyPostIds.has(post.id)}
                 onFavoriteToggle={handleFavoriteToggle}
                 onClick={handlePostClick}
+                onReport={handlePostReport}
               />
             ))}
 

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearchResults.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearchResults.tsx
@@ -11,6 +11,7 @@ import { SocialPostCard } from "@/components/features/social/SocialPostCard/Soci
 import { Button } from "@/components/shared/Button/Button";
 import { Loader } from "@/components/shared/Loader/Loader";
 import { useToast } from "@/contexts/ToastContext";
+import { reportPost } from "@/lib/api/client";
 import { useSearchHistory } from "@/lib/hooks/useSearchHistory";
 import { useSocialFavorite } from "@/lib/hooks/useSocialFavorite";
 import { useSocialSearch } from "@/lib/hooks/useSocialSearch";
@@ -84,6 +85,28 @@ export const SocialSearchResults = forwardRef<
       router.push(`/social/posts/${postId}`);
     },
     [router],
+  );
+
+  const handlePostReport = useCallback(
+    async (
+      postId: string,
+      reason:
+        | "spam"
+        | "harassment"
+        | "inappropriate"
+        | "impersonation"
+        | "other",
+      detail?: string,
+    ) => {
+      if (!userId) return;
+      try {
+        await reportPost({ postId, user_id: userId, reason, detail });
+        showToast(t("reportSuccess"), "success");
+      } catch {
+        showToast(t("reportFailed"), "error");
+      }
+    },
+    [userId, showToast, t],
   );
 
   const handleHistoryItemClick = useCallback(
@@ -216,6 +239,7 @@ export const SocialSearchResults = forwardRef<
             currentUserId={userId ?? ""}
             onFavoriteToggle={handleFavoriteToggle}
             onClick={handlePostClick}
+            onReport={handlePostReport}
           />
         ))
       )}

--- a/frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx
+++ b/frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx
@@ -18,7 +18,11 @@ import { SocialHeader } from "@/components/shared/layouts/SocialLayout";
 import { SignupPromptModal } from "@/components/shared/SignupPromptModal/SignupPromptModal";
 import { Tooltip } from "@/components/shared/Tooltip";
 import { useToast } from "@/contexts/ToastContext";
-import { getPublicSocialProfile, getSocialProfile } from "@/lib/api/client";
+import {
+  getPublicSocialProfile,
+  getSocialProfile,
+  reportPost,
+} from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useSocialFavorite } from "@/lib/hooks/useSocialFavorite";
 import { useSwipeNavigation } from "@/lib/hooks/useSwipeNavigation";
@@ -147,6 +151,33 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
       router.push(`/social/posts/${postId}`);
     },
     [router, isAuthenticated, handleSignupPromptOpen],
+  );
+
+  const handlePostReport = useCallback(
+    async (
+      postId: string,
+      reason:
+        | "spam"
+        | "harassment"
+        | "inappropriate"
+        | "impersonation"
+        | "other",
+      detail?: string,
+    ) => {
+      if (!currentUser?.id) return;
+      try {
+        await reportPost({
+          postId,
+          user_id: currentUser.id,
+          reason,
+          detail,
+        });
+        showToast(t("reportSuccess"), "success");
+      } catch {
+        showToast(t("reportFailed"), "error");
+      }
+    },
+    [currentUser?.id, showToast, t],
   );
 
   const handleBack = useCallback(() => {
@@ -363,6 +394,7 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
                 currentUserId={currentUser?.id ?? ""}
                 onFavoriteToggle={handleFavoriteToggle}
                 onClick={handlePostClick}
+                onReport={handlePostReport}
               />
             ))
           ))}
@@ -378,6 +410,7 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
                 currentUserId={currentUser?.id ?? ""}
                 onFavoriteToggle={handleFavoriteToggle}
                 onClick={handlePostClick}
+                onReport={handlePostReport}
               />
             ))
           ))}

--- a/frontend/src/components/features/social/SocialPostCard/SocialPostCard.module.css
+++ b/frontend/src/components/features/social/SocialPostCard/SocialPostCard.module.css
@@ -26,6 +26,63 @@
   margin-bottom: 8px;
 }
 
+.menuWrapper {
+  position: relative;
+  margin-left: auto;
+}
+
+.menuButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--light-gray);
+  border-radius: 50%;
+  transition: color 0.2s;
+  min-width: unset;
+  padding: 0;
+  font-family: inherit;
+  letter-spacing: normal;
+}
+
+.menuButton:hover {
+  color: var(--text-light);
+}
+
+.menuDropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  min-width: 120px;
+  background: var(--white);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: var(--z-header-dropdown);
+  overflow: hidden;
+}
+
+.menuItem {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  font-size: var(--font-size-sm);
+  color: var(--black);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.menuItem:hover {
+  background: var(--background-light);
+}
+
 .authorInfo {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/features/social/SocialPostCard/SocialPostCard.tsx
+++ b/frontend/src/components/features/social/SocialPostCard/SocialPostCard.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { ChatDotsIcon, HeartIcon, ShareFatIcon } from "@phosphor-icons/react";
+import {
+  ChatDotsIcon,
+  DotsThreeVerticalIcon,
+  HeartIcon,
+  ShareFatIcon,
+} from "@phosphor-icons/react";
+import dynamic from "next/dynamic";
 import { useLocale, useTranslations } from "next-intl";
 import { type FC, memo, useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/shared/Button/Button";
@@ -13,6 +19,21 @@ import { formatToRelativeTime } from "@/lib/utils/dateUtils";
 import { buildShareUrl } from "@/lib/utils/share";
 import { SocialMediaGrid } from "./SocialMediaGrid";
 import styles from "./SocialPostCard.module.css";
+
+const ReportModal = dynamic(
+  () =>
+    import("@/components/features/social/ReportModal/ReportModal").then(
+      (m) => m.ReportModal,
+    ),
+  { ssr: false },
+);
+
+type ReportReason =
+  | "spam"
+  | "harassment"
+  | "inappropriate"
+  | "impersonation"
+  | "other";
 
 interface SocialPostAuthor {
   id: string;
@@ -60,6 +81,11 @@ interface SocialPostCardProps {
   hasUnreadReplies?: boolean;
   onFavoriteToggle: (postId: string) => void;
   onClick: (postId: string) => void;
+  /**
+   * 通報送信時のハンドラ。指定された場合のみ、自分以外の投稿に kebab メニュー +
+   * 「通報する」項目が表示される。Apple App Review Guideline 1.2 (UGC) 対応。
+   */
+  onReport?: (postId: string, reason: ReportReason, detail?: string) => void;
 }
 
 export const SocialPostCard: FC<SocialPostCardProps> = memo(
@@ -69,6 +95,7 @@ export const SocialPostCard: FC<SocialPostCardProps> = memo(
     hasUnreadReplies,
     onFavoriteToggle,
     onClick,
+    onReport,
   }) {
     const t = useTranslations("socialPosts");
     const locale = useLocale();
@@ -76,7 +103,12 @@ export const SocialPostCard: FC<SocialPostCardProps> = memo(
     const { track } = useUmamiTrack();
     const [isExpanded, setIsExpanded] = useState(false);
     const [isTruncated, setIsTruncated] = useState(false);
+    const [showMenu, setShowMenu] = useState(false);
+    const [showReportModal, setShowReportModal] = useState(false);
     const textRef = useRef<HTMLParagraphElement>(null);
+    const menuRef = useRef<HTMLDivElement>(null);
+    const isOwner = post.user_id === currentUserId;
+    const showMenuButton = !isOwner && !!onReport;
 
     // ResizeObserverでtruncation検出（layout thrashing回避）
     useEffect(() => {
@@ -91,6 +123,26 @@ export const SocialPostCard: FC<SocialPostCardProps> = memo(
       observer.observe(el);
       return () => observer.disconnect();
     }, []);
+
+    // メニュー外クリックで閉じる
+    useEffect(() => {
+      if (!showMenu) return;
+      const handleClickOutside = (e: MouseEvent) => {
+        if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+          setShowMenu(false);
+        }
+      };
+      document.addEventListener("click", handleClickOutside);
+      return () => document.removeEventListener("click", handleClickOutside);
+    }, [showMenu]);
+
+    const handleReportSubmit = useCallback(
+      (reason: ReportReason, detail?: string) => {
+        onReport?.(post.id, reason, detail);
+        setShowReportModal(false);
+      },
+      [onReport, post.id],
+    );
 
     const handleShare = useCallback(
       async (e: React.MouseEvent) => {
@@ -158,6 +210,35 @@ export const SocialPostCard: FC<SocialPostCardProps> = memo(
               </span>
             </span>
           </div>
+          {showMenuButton && (
+            <div className={styles.menuWrapper} ref={menuRef}>
+              <Button
+                className={styles.menuButton}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowMenu((prev) => !prev);
+                }}
+                aria-label={t("menuReport")}
+              >
+                <DotsThreeVerticalIcon size={16} weight="bold" />
+              </Button>
+              {showMenu && (
+                <div className={styles.menuDropdown}>
+                  <button
+                    type="button"
+                    className={styles.menuItem}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowMenu(false);
+                      setShowReportModal(true);
+                    }}
+                  >
+                    {t("menuReport")}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         <div className={styles.content}>
@@ -257,6 +338,15 @@ export const SocialPostCard: FC<SocialPostCardProps> = memo(
             <ShareFatIcon size={20} weight="regular" />
           </Button>
         </div>
+
+        {showMenuButton && (
+          <ReportModal
+            isOpen={showReportModal}
+            onClose={() => setShowReportModal(false)}
+            onSubmit={handleReportSubmit}
+            title={t("reportTitle")}
+          />
+        )}
       </div>
     );
   },


### PR DESCRIPTION
## Summary

Apple App Review Guideline 1.2 (User-Generated Content) で要求される **「objectionable content を flag できる仕組み」をフィード/プロフィール/検索結果のすべての投稿カードからアクセス可能にする** ため、`SocialPostCard` に kebab メニュー（… アイコン）を追加し、「通報する」項目を出すよう変更しました。

これは Apple iOS 版審査リジェクト対応プランの **Phase 2 (PR-2)** に該当します。

## 変更内容

### `SocialPostCard.tsx` (+ `.module.css`)
- `DotsThreeVerticalIcon` を author header の右端に配置
- `ReportModal` を `dynamic import`（既存の `SocialReplyItem` と同じパターン）
- 新規 props: `onReport?: (postId, reason, detail) => void`
  - **optional** にすることで未対応の親 (`TrainingCard.tsx` 等) や Storybook 既存ストーリーへの影響をゼロに
  - 自分の投稿の場合は kebab を表示しない (`isOwner` 判定)
  - `onReport` が渡されていない親 (Storybook 等) でも kebab を表示しない

### 親コンポーネントへの `handlePostReport` 追加
すべて既存の `reportPost` API クライアント (`lib/api/client.ts:767`) と既存 i18n キー (`reportSuccess` / `reportFailed` / `menuReport` / `reportTitle`) を流用:

- `frontend/src/app/[locale]/(authenticated)/(tabbed)/social/posts/SocialPostsFeed.tsx` — フィード
- `frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx` — プロフィール画面（posts / training 両タブ）
- `frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearchResults.tsx` — 検索結果

## 動作

- 他人の投稿カード右上に kebab (`⋮`) が表示される
- タップで「通報する」項目のみのドロップダウンが出る
- 選択すると既存の `ReportModal`（5理由 + 500字 detail）が開く
- 送信成功で `通報を送信しました` トースト、失敗で `通報の送信に失敗しました` トースト
- バックエンドエンドポイント `POST /api/social/reports/posts/:id` は既存のまま、追加の DB マイグレーション無し

## 何をしないか
- 自分の投稿への kebab 追加（編集/削除導線は別場所で扱われており、別 PR で取り扱う場合のみ）
- ブロック機能（次フェーズ Phase 3 で対応）
- `SocialPostDetail.tsx` には既に投稿の通報メニューが実装済みのため、今回は触らない

## Test plan

- [x] `tsc --noEmit` 通過（frontend / backend 両方）
- [x] `pnpm check`（既存 warnings のみ、新規 lint エラーなし）
- [x] pre-commit フック通過
- [x] Vercel preview デプロイで以下を確認
  - [x] フィードで他人の投稿に kebab が表示される
  - [x] フィードで自分の投稿には kebab が表示されない
  - [x] kebab → 「通報する」→ ReportModal で 5 理由 + 詳細を入力 → submit → トースト表示
  - [x] プロフィール画面の posts / training 両タブで同様
  - [x] 検索結果でも同様
  - [x] 通報後 Supabase の `PostReport` テーブルに行が入る
- [ ] Apple 再申請時のスクリーン録画用に「kebab → 通報 → ReportModal → submit」の流れを撮影

## Related

Apple App Review リジェクト対応プラン全体の Phase 2。先行: #293 (Phase 1 NG ワード拒否化)。後続: Phase 3 ユーザーブロック機能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)