### PR TITLE
feat: UserBlockテーブルとフィード双方向ブロック除外を追加（Apple Guideline 1.2 対応）

### DIFF
--- a/backend/src/migrations/023_create_user_block.sql
+++ b/backend/src/migrations/023_create_user_block.sql
@@ -1,0 +1,49 @@
+-- 023_create_user_block.sql
+-- ユーザーブロック機能: UserBlockテーブルの新設
+-- Apple App Review Guideline 1.2 (UGC) 対応
+
+-- 1. UserBlockテーブル作成
+CREATE TABLE IF NOT EXISTS "UserBlock" (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  blocker_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  blocked_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT unique_user_block UNIQUE (blocker_user_id, blocked_user_id),
+  CONSTRAINT cannot_self_block CHECK (blocker_user_id <> blocked_user_id)
+);
+
+-- 2. RLS有効化
+ALTER TABLE "UserBlock" ENABLE ROW LEVEL SECURITY;
+
+-- authenticatedロール用ポリシー
+-- 自分のブロックリストのみ閲覧可能（被ブロック側は自分がブロックされている事実を認識できない）
+CREATE POLICY "Users can view own blocks"
+  ON "UserBlock"
+  FOR SELECT
+  TO authenticated
+  USING (blocker_user_id = auth.uid());
+
+CREATE POLICY "Users can insert own blocks"
+  ON "UserBlock"
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (blocker_user_id = auth.uid());
+
+CREATE POLICY "Users can delete own blocks"
+  ON "UserBlock"
+  FOR DELETE
+  TO authenticated
+  USING (blocker_user_id = auth.uid());
+
+-- service_roleフルアクセス（Hono backend が SERVICE_ROLE_KEY で双方向ブロック判定を行うため必須）
+CREATE POLICY "Service role full access on UserBlock"
+  ON "UserBlock"
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- 3. インデックス（双方向ルックアップ用）
+CREATE INDEX idx_user_block_blocker_id ON "UserBlock" (blocker_user_id);
+CREATE INDEX idx_user_block_blocked_id ON "UserBlock" (blocked_user_id);

--- a/backend/src/migrations/024_filter_blocked_users_in_feed.sql
+++ b/backend/src/migrations/024_filter_blocked_users_in_feed.sql
@@ -1,0 +1,103 @@
+-- ============================================
+-- 024_filter_blocked_users_in_feed.sql
+-- get_social_feed 関数を双方向のブロック除外付きに更新
+-- Apple App Review Guideline 1.2 (UGC) 対応
+--
+-- 015 で更新された関数定義をベースに、WHERE 句に「viewer → 投稿主」「投稿主 → viewer」
+-- 双方向の UserBlock 除外を追加。スコアリングロジック等は 015 から変更なし。
+-- ============================================
+CREATE OR REPLACE FUNCTION get_social_feed(
+  viewer_user_id UUID,
+  viewer_dojo_style_id UUID,
+  tab_filter TEXT,
+  feed_limit INT,
+  feed_offset INT
+)
+RETURNS TABLE (
+  id UUID,
+  user_id UUID,
+  content TEXT,
+  post_type TEXT,
+  author_dojo_style_id UUID,
+  author_dojo_name TEXT,
+  favorite_count INT,
+  reply_count INT,
+  source_page_id UUID,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  feed_score DOUBLE PRECISION
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    sp.id,
+    sp.user_id,
+    sp.content,
+    sp.post_type,
+    sp.author_dojo_style_id,
+    sp.author_dojo_name,
+    sp.favorite_count,
+    sp.reply_count,
+    sp.source_page_id,
+    sp.created_at,
+    sp.updated_at,
+    (
+      EXTRACT(EPOCH FROM sp.created_at) / 3600.0
+      + sp.favorite_count * 2
+      + sp.reply_count * 3
+      -- 鮮度ボーナス（なだらかな4段階）
+      + CASE
+          WHEN sp.created_at > now() - INTERVAL '6 hours'  THEN 60
+          WHEN sp.created_at > now() - INTERVAL '24 hours' THEN 45
+          WHEN sp.created_at > now() - INTERVAL '72 hours' THEN 25
+          WHEN sp.created_at > now() - INTERVAL '7 days'   THEN 10
+          ELSE 0
+        END
+      -- 新規ユーザーブースト
+      + CASE
+          WHEN u.created_at > now() - INTERVAL '14 days' THEN 30
+          WHEN u.created_at > now() - INTERVAL '30 days' THEN 15
+          ELSE 0
+        END
+      -- ランダムジッター（表示順の多様性確保）
+      + (random() * 15)
+    )::DOUBLE PRECISION AS feed_score
+  FROM "SocialPost" sp
+  JOIN "User" u ON u.id = sp.user_id
+  LEFT JOIN "SocialFavorite" sf
+    ON sf.post_id = sp.id AND sf.user_id = viewer_user_id
+  WHERE sp.is_deleted = false
+    AND (
+      u.publicity_setting = 'public'
+      OR (
+        u.publicity_setting = 'closed'
+        AND viewer_dojo_style_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM "UserPublicityDojo" upd
+          WHERE upd.user_id = sp.user_id
+            AND upd.dojo_style_id = viewer_dojo_style_id
+        )
+      )
+      OR sp.user_id = viewer_user_id
+    )
+    -- ブロック関係の除外（双方向）: viewer がブロックした相手 / viewer をブロックした相手の投稿は表示しない
+    AND NOT EXISTS (
+      SELECT 1 FROM "UserBlock" ub1
+      WHERE ub1.blocker_user_id = viewer_user_id
+        AND ub1.blocked_user_id = sp.user_id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM "UserBlock" ub2
+      WHERE ub2.blocker_user_id = sp.user_id
+        AND ub2.blocked_user_id = viewer_user_id
+    )
+    AND (
+      tab_filter = 'all'
+      OR (tab_filter = 'training' AND sp.post_type = 'training_record')
+      OR (tab_filter = 'favorites' AND sf.id IS NOT NULL)
+    )
+  ORDER BY feed_score DESC
+  LIMIT feed_limit
+  OFFSET feed_offset;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Apple App Review Guideline 1.2 (UGC) で要求される **「abusive ユーザーをブロックできる」** 機能の DB 基盤を追加します。

これは Apple iOS 版審査リジェクト対応プランの **Phase 3 (PR-3a)** に該当します。後続 PR (3b: Backend, 3c: Frontend) でこのテーブルを使った機能を順次積み上げる予定です。

## 変更内容

### `023_create_user_block.sql`
新規 `UserBlock` テーブル + RLS:

| カラム | 型 | 備考 |
|---|---|---|
| `id` | uuid PK | gen_random_uuid() |
| `blocker_user_id` | uuid FK | `auth.users(id) ON DELETE CASCADE` |
| `blocked_user_id` | uuid FK | 同上 |
| `created_at` | timestamptz | now() |

- `UNIQUE (blocker_user_id, blocked_user_id)` で同一ペアの二重 INSERT 防止
- `CHECK (blocker_user_id <> blocked_user_id)` で自己ブロック禁止
- インデックス: `blocker_user_id` / `blocked_user_id` 双方向ルックアップ用

#### RLS ポリシー（022 のパターン踏襲）
- **authenticated ロール**:
  - `SELECT` / `INSERT` / `DELETE` を `blocker_user_id = auth.uid()` で制限 — 自分のブロックリストのみ可視・操作可
  - **被ブロック側からは `SELECT` 不可**（自分がブロックされている事実は SELECT で確認できない）
- **service_role ロール**: `ALL` 許可（Hono backend が `SERVICE_ROLE_KEY` で双方向判定を行うため必須）

### `024_filter_blocked_users_in_feed.sql`
`get_social_feed(...)` 関数を `CREATE OR REPLACE` で更新。

- 015 (improve_feed_scoring) のスコアリングロジック・パラメータは変更なし
- WHERE 句に **双方向の `NOT EXISTS UserBlock`** を 2 つ追加:
  - `viewer → 投稿主` (自分がブロックした相手の投稿を非表示)
  - `投稿主 → viewer` (自分をブロックした相手の投稿を非表示)
- 自分の投稿は既存の `OR sp.user_id = viewer_user_id` で表示されるため、ブロック判定は他人にのみ作用

## マージ後の手順（運用）

このマイグレーションは Supabase に反映が必要です:

1. `npx supabase db push` (もしくは Supabase Studio から SQL 実行) でマイグレーション適用
2. 既存データへの影響: なし（純粋な追加。`get_social_feed` は CREATE OR REPLACE なのでロジック差分のみ反映、既存スコアリングは保持）
3. 適用後、Supabase Studio で `UserBlock` テーブルが作成され、RLS が有効化されていることを確認

## Test plan

DB レベルなので backend の vitest 直接対象ではないが、**マージ後** に以下を手動確認:

- [ ] Supabase Studio で `UserBlock` テーブルが作成済み・RLS ON
- [ ] 認証済み別アカウントから `INSERT INTO "UserBlock"` でブロック行作成 → SELECT で自分のものだけ見える
- [ ] `SELECT * FROM get_social_feed(...)` でブロックした投稿主の投稿が消えることを確認（双方向）
- [ ] backend (`pnpm dev`) でフィード取得 (`GET /api/social/posts`) が以前同様に動作

## Related

- リジェクト対応プラン全体: 先行 #293 (Phase 1)・#294 (Phase 2) マージ済み
- 後続: PR-3b (user-blocks ルート + supabase.ts ヘルパー + getSocialProfile 統合)、PR-3c (Frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)