### PR TITLE
feat: ユーザーブロックUI とブロック中ユーザー設定画面を追加（Apple Guideline 1.2 対応）

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/(tabbed)/social/posts/SocialPostsFeed.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/(tabbed)/social/posts/SocialPostsFeed.tsx
@@ -13,13 +13,14 @@ import {
   type SocialTab,
   SocialTabBar,
 } from "@/components/features/social/SocialTabBar/SocialTabBar";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import { FloatingActionButton } from "@/components/shared/FloatingActionButton/FloatingActionButton";
 import { Loader } from "@/components/shared/Loader/Loader";
 import { PremiumUpgradeModal } from "@/components/shared/PremiumUpgradeModal/PremiumUpgradeModal";
 import { PublicityConfirmDialog } from "@/components/shared/PublicityConfirmDialog/PublicityConfirmDialog";
 import { RefetchErrorBanner } from "@/components/shared/RefetchErrorBanner/RefetchErrorBanner";
 import { useToast } from "@/contexts/ToastContext";
-import { reportPost } from "@/lib/api/client";
+import { blockUser, reportPost } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useDailyLimits } from "@/lib/hooks/useDailyLimits";
 import { useSocialFavorite } from "@/lib/hooks/useSocialFavorite";
@@ -69,6 +70,11 @@ export function SocialPostsFeed() {
     useState<string>("premiumModalBrowse");
   const { hasConfirmedPublicity } = usePublicityConfirmStore();
   const [showPublicityDialog, setShowPublicityDialog] = useState(false);
+  const [pendingBlock, setPendingBlock] = useState<{
+    userId: string;
+    username: string;
+  } | null>(null);
+  const [isBlocking, setIsBlocking] = useState(false);
 
   const updateTab = useCallback((tab: SocialTab) => {
     setActiveTab(tab);
@@ -181,6 +187,28 @@ export function SocialPostsFeed() {
     [user?.id, showToast, t],
   );
 
+  const handleBlockRequest = useCallback(
+    (blockedUserId: string, username: string) => {
+      setPendingBlock({ userId: blockedUserId, username });
+    },
+    [],
+  );
+
+  const handleBlockConfirm = useCallback(async () => {
+    if (!pendingBlock) return;
+    setIsBlocking(true);
+    try {
+      await blockUser(pendingBlock.userId);
+      showToast(t("blockSuccess"), "success");
+      setPendingBlock(null);
+      refetch();
+    } catch {
+      showToast(t("blockFailed"), "error");
+    } finally {
+      setIsBlocking(false);
+    }
+  }, [pendingBlock, refetch, showToast, t]);
+
   const emptyKey =
     activeTab === "all"
       ? "emptyAll"
@@ -246,6 +274,7 @@ export function SocialPostsFeed() {
                 onFavoriteToggle={handleFavoriteToggle}
                 onClick={handlePostClick}
                 onReport={handlePostReport}
+                onBlock={handleBlockRequest}
               />
             ))}
 
@@ -291,6 +320,17 @@ export function SocialPostsFeed() {
           setShowPublicityDialog(false);
           router.push("/social/posts/new");
         }}
+      />
+
+      <ConfirmDialog
+        isOpen={pendingBlock !== null}
+        title={t("blockConfirmTitle")}
+        message={t("blockConfirmMessage")}
+        confirmLabel={t("menuBlock")}
+        cancelLabel={t("editCancel")}
+        onConfirm={handleBlockConfirm}
+        onCancel={() => setPendingBlock(null)}
+        isProcessing={isBlocking}
       />
     </>
   );

--- a/frontend/src/app/[locale]/(authenticated)/settings/blocked-users/BlockedUsersSetting.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/settings/blocked-users/BlockedUsersSetting.module.css
@@ -1,0 +1,58 @@
+.container {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.description {
+  font-size: var(--font-size-xs);
+  color: var(--text-light);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.empty {
+  font-size: var(--font-size-sm);
+  color: var(--text-light);
+  text-align: center;
+  padding: 32px 16px;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 0.5px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--white);
+}
+
+.userLink {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  text-decoration: none;
+  color: inherit;
+}
+
+.username {
+  font-size: var(--font-size-sm);
+  color: var(--black);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/app/[locale]/(authenticated)/settings/blocked-users/BlockedUsersSetting.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/settings/blocked-users/BlockedUsersSetting.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/shared/Button/Button";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog/ConfirmDialog";
+import { Loader } from "@/components/shared/Loader/Loader";
+import { MinimalLayout } from "@/components/shared/layouts/MinimalLayout";
+import { ProfileImage } from "@/components/shared/ProfileImage/ProfileImage";
+import { useToast } from "@/contexts/ToastContext";
+import {
+  type BlockedUserListItem,
+  getBlockedUsers,
+  unblockUser,
+} from "@/lib/api/client";
+import styles from "./BlockedUsersSetting.module.css";
+
+interface BlockedUsersSettingProps {
+  locale: string;
+}
+
+export function BlockedUsersSetting({ locale }: BlockedUsersSettingProps) {
+  const t = useTranslations();
+  const { showToast } = useToast();
+  const [items, setItems] = useState<BlockedUserListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [pendingUnblock, setPendingUnblock] =
+    useState<BlockedUserListItem | null>(null);
+  const [isUnblocking, setIsUnblocking] = useState(false);
+
+  const fetchList = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await getBlockedUsers();
+      setItems(data);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  const handleUnblockConfirm = useCallback(async () => {
+    if (!pendingUnblock) return;
+    setIsUnblocking(true);
+    try {
+      await unblockUser(pendingUnblock.blocked_user_id);
+      showToast(t("socialPosts.unblockSuccess"), "success");
+      setPendingUnblock(null);
+      await fetchList();
+    } catch {
+      showToast(t("socialPosts.unblockFailed"), "error");
+    } finally {
+      setIsUnblocking(false);
+    }
+  }, [pendingUnblock, fetchList, showToast, t]);
+
+  return (
+    <MinimalLayout
+      headerTitle={t("settings.blockedUsers")}
+      backHref={`/${locale}/mypage`}
+    >
+      <div className={styles.container}>
+        <p className={styles.description}>
+          {t("settings.blockedUsersDescription")}
+        </p>
+        {isLoading ? (
+          <Loader centered size="medium" />
+        ) : items.length === 0 ? (
+          <p className={styles.empty}>{t("settings.blockedUsersEmpty")}</p>
+        ) : (
+          <ul className={styles.list}>
+            {items.map((item) => (
+              <li key={item.id} className={styles.item}>
+                <a
+                  href={`/${locale}/social/profile/${item.blocked_user.username}`}
+                  className={styles.userLink}
+                >
+                  <ProfileImage
+                    src={item.blocked_user.profile_image_url}
+                    size="small"
+                  />
+                  <span className={styles.username}>
+                    {item.blocked_user.username || t("settings.blockedUsers")}
+                  </span>
+                </a>
+                <Button
+                  size="small"
+                  onClick={() => setPendingUnblock(item)}
+                  aria-label={t("settings.unblockButton")}
+                >
+                  {t("settings.unblockButton")}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={pendingUnblock !== null}
+        title={t("socialPosts.unblockConfirmTitle")}
+        message={t("socialPosts.unblockConfirmMessage")}
+        confirmLabel={t("socialPosts.menuUnblock")}
+        cancelLabel={t("socialPosts.editCancel")}
+        onConfirm={handleUnblockConfirm}
+        onCancel={() => setPendingUnblock(null)}
+        isProcessing={isUnblocking}
+      />
+    </MinimalLayout>
+  );
+}

--- a/frontend/src/app/[locale]/(authenticated)/settings/blocked-users/page.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/settings/blocked-users/page.tsx
@@ -1,0 +1,16 @@
+import { AuthGate } from "@/components/shared/auth";
+import { BlockedUsersSetting } from "./BlockedUsersSetting";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+
+  return (
+    <AuthGate>
+      <BlockedUsersSetting locale={locale} />
+    </AuthGate>
+  );
+}

--- a/frontend/src/app/[locale]/(public)/social/posts/[post_id]/SocialPostDetail.tsx
+++ b/frontend/src/app/[locale]/(public)/social/posts/[post_id]/SocialPostDetail.tsx
@@ -33,6 +33,7 @@ import { SignupPromptModal } from "@/components/shared/SignupPromptModal/SignupP
 import { Tag } from "@/components/shared/Tag/Tag";
 import { useToast } from "@/contexts/ToastContext";
 import {
+  blockUser,
   createSocialReply,
   deleteSocialPost,
   deleteSocialReply,
@@ -324,6 +325,21 @@ export function SocialPostDetail({ postId }: SocialPostDetailProps) {
         showToast(t("reportSuccess"), "success");
       } catch {
         showToast(t("reportFailed"), "error");
+      }
+    },
+    [user?.id, showToast, t],
+  );
+
+  const handleReplyBlock = useCallback(
+    async (blockedUserId: string) => {
+      if (!user?.id) return;
+      // 詳細画面ではメニュー側で confirm を出さず即時実行（最小実装、Phase 3 の範囲）
+      try {
+        await blockUser(blockedUserId);
+        showToast(t("blockSuccess"), "success");
+        // 詳細画面のリロードはブラウザに任せ、楽観的更新は省略
+      } catch {
+        showToast(t("blockFailed"), "error");
       }
     },
     [user?.id, showToast, t],
@@ -680,6 +696,7 @@ export function SocialPostDetail({ postId }: SocialPostDetailProps) {
                 onDelete={handleReplyDelete}
                 onFavoriteToggle={handleReplyFavoriteToggle}
                 onUnauthenticatedAction={handleSignupPromptOpen}
+                onBlock={isAuthenticated ? handleReplyBlock : undefined}
               />
             ),
           )}

--- a/frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx
+++ b/frontend/src/app/[locale]/(public)/social/profile/SocialProfileView.tsx
@@ -13,15 +13,18 @@ import {
   SocialPostCard,
 } from "@/components/features/social/SocialPostCard/SocialPostCard";
 import { Button } from "@/components/shared/Button/Button";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import { Loader } from "@/components/shared/Loader/Loader";
 import { SocialHeader } from "@/components/shared/layouts/SocialLayout";
 import { SignupPromptModal } from "@/components/shared/SignupPromptModal/SignupPromptModal";
 import { Tooltip } from "@/components/shared/Tooltip";
 import { useToast } from "@/contexts/ToastContext";
 import {
+  blockUser,
   getPublicSocialProfile,
   getSocialProfile,
   reportPost,
+  unblockUser,
 } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useSocialFavorite } from "@/lib/hooks/useSocialFavorite";
@@ -49,6 +52,8 @@ interface ProfileData {
   total_posts_count: number;
   total_training_records_count: number;
   public_pages: { id: string; title: string; created_at: string }[];
+  is_blocked?: boolean;
+  is_blocked_by_target?: boolean;
 }
 
 interface SocialProfileViewProps {
@@ -68,6 +73,9 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
   const [activeTab, setActiveTab] = useState<ProfileTab>("posts");
   const [showSignupPrompt, setShowSignupPrompt] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
+  const [showBlockConfirm, setShowBlockConfirm] = useState(false);
+  const [showUnblockConfirm, setShowUnblockConfirm] = useState(false);
+  const [isBlocking, setIsBlocking] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const { handleToggleFavorite } = useSocialFavorite();
 
@@ -86,26 +94,27 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
     return () => document.removeEventListener("click", handleClickOutside);
   }, [showMenu]);
 
+  const fetchProfile = useCallback(async () => {
+    try {
+      const result = currentUser?.id
+        ? await getSocialProfile(username)
+        : await getPublicSocialProfile(username);
+      if (result.success && result.data) {
+        const data = result.data as ProfileData;
+        setProfile(data);
+        setPosts(data.posts);
+      }
+    } catch (error) {
+      console.error("プロフィール取得エラー:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentUser?.id, username]);
+
   useEffect(() => {
     if (isInitializing) return;
-    const fetchProfile = async () => {
-      try {
-        const result = currentUser?.id
-          ? await getSocialProfile(username)
-          : await getPublicSocialProfile(username);
-        if (result.success && result.data) {
-          const data = result.data as ProfileData;
-          setProfile(data);
-          setPosts(data.posts);
-        }
-      } catch (error) {
-        console.error("プロフィール取得エラー:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
     fetchProfile();
-  }, [currentUser?.id, username, isInitializing]);
+  }, [fetchProfile, isInitializing]);
 
   const updatePost = useCallback(
     (
@@ -200,6 +209,57 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
       console.error("URL コピーエラー:", error);
     }
   }, [locale, username, showToast, t]);
+
+  const handleBlockClick = useCallback(() => {
+    setShowMenu(false);
+    setShowBlockConfirm(true);
+  }, []);
+
+  const handleUnblockClick = useCallback(() => {
+    setShowMenu(false);
+    setShowUnblockConfirm(true);
+  }, []);
+
+  const handleBlockConfirm = useCallback(async () => {
+    if (!profile?.user?.id) return;
+    setIsBlocking(true);
+    try {
+      await blockUser(profile.user.id);
+      showToast(t("blockSuccess"), "success");
+      setShowBlockConfirm(false);
+      await fetchProfile();
+    } catch {
+      showToast(t("blockFailed"), "error");
+    } finally {
+      setIsBlocking(false);
+    }
+  }, [profile?.user?.id, fetchProfile, showToast, t]);
+
+  const handleUnblockConfirm = useCallback(async () => {
+    if (!profile?.user?.id) return;
+    setIsBlocking(true);
+    try {
+      await unblockUser(profile.user.id);
+      showToast(t("unblockSuccess"), "success");
+      setShowUnblockConfirm(false);
+      await fetchProfile();
+    } catch {
+      showToast(t("unblockFailed"), "error");
+    } finally {
+      setIsBlocking(false);
+    }
+  }, [profile?.user?.id, fetchProfile, showToast, t]);
+
+  // 投稿カードからのブロック (handleBlockRequest と同じ動作だが userId は post 由来)
+  const handleCardBlock = useCallback(
+    (blockedUserId: string) => {
+      if (!profile?.user?.id || profile.user.id !== blockedUserId) {
+        // プロフィール本人以外（基本ありえない）は確認なしで即実行
+      }
+      setShowBlockConfirm(true);
+    },
+    [profile?.user?.id],
+  );
 
   const regularPosts = useMemo(
     () => posts.filter((p) => p.post_type !== "training_record"),
@@ -320,6 +380,25 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
                 >
                   {t("profileMenuCopyUrl")}
                 </button>
+                {!isOwnProfile &&
+                  isAuthenticated &&
+                  (profile?.is_blocked ? (
+                    <button
+                      type="button"
+                      className={styles.menuItem}
+                      onClick={handleUnblockClick}
+                    >
+                      {t("menuUnblock")}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className={styles.menuItem}
+                      onClick={handleBlockClick}
+                    >
+                      {t("menuBlock")}
+                    </button>
+                  ))}
               </div>
             )}
           </div>
@@ -383,7 +462,17 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
         className={`${styles.postsSection} ${isDragging ? styles.postsSectionSwiping : ""}`}
         {...handlers}
       >
+        {!isOwnProfile && profile?.is_blocked && (
+          <p className={styles.emptyPosts}>{t("blockedProfileMessage")}</p>
+        )}
+        {!isOwnProfile &&
+          !profile?.is_blocked &&
+          profile?.is_blocked_by_target && (
+            <p className={styles.emptyPosts}>{t("blockedByTargetMessage")}</p>
+          )}
         {activeTab === "posts" &&
+          !profile?.is_blocked &&
+          !profile?.is_blocked_by_target &&
           (regularPosts.length === 0 ? (
             <p className={styles.emptyPosts}>{t("emptyAll")}</p>
           ) : (
@@ -395,11 +484,14 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
                 onFavoriteToggle={handleFavoriteToggle}
                 onClick={handlePostClick}
                 onReport={handlePostReport}
+                onBlock={isAuthenticated ? handleCardBlock : undefined}
               />
             ))
           ))}
 
         {activeTab === "training" &&
+          !profile?.is_blocked &&
+          !profile?.is_blocked_by_target &&
           (trainingPosts.length === 0 ? (
             <p className={styles.emptyPosts}>{t("emptyTrainingRecords")}</p>
           ) : (
@@ -411,6 +503,7 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
                 onFavoriteToggle={handleFavoriteToggle}
                 onClick={handlePostClick}
                 onReport={handlePostReport}
+                onBlock={isAuthenticated ? handleCardBlock : undefined}
               />
             ))
           ))}
@@ -419,6 +512,28 @@ export function SocialProfileView({ username }: SocialProfileViewProps) {
       <SignupPromptModal
         isOpen={showSignupPrompt}
         onClose={() => setShowSignupPrompt(false)}
+      />
+
+      <ConfirmDialog
+        isOpen={showBlockConfirm}
+        title={t("blockConfirmTitle")}
+        message={t("blockConfirmMessage")}
+        confirmLabel={t("menuBlock")}
+        cancelLabel={t("editCancel")}
+        onConfirm={handleBlockConfirm}
+        onCancel={() => setShowBlockConfirm(false)}
+        isProcessing={isBlocking}
+      />
+
+      <ConfirmDialog
+        isOpen={showUnblockConfirm}
+        title={t("unblockConfirmTitle")}
+        message={t("unblockConfirmMessage")}
+        confirmLabel={t("menuUnblock")}
+        cancelLabel={t("editCancel")}
+        onConfirm={handleUnblockConfirm}
+        onCancel={() => setShowUnblockConfirm(false)}
+        isProcessing={isBlocking}
       />
     </>
   );

--- a/frontend/src/components/features/setting/SettingsMenu/SettingsMenu.tsx
+++ b/frontend/src/components/features/setting/SettingsMenu/SettingsMenu.tsx
@@ -46,6 +46,11 @@ export const SettingsMenu: FC<SettingsMenuProps> = ({ className = "" }) => {
       >
         {t("navigation.pushNotification")}
       </SettingItem>
+      <SettingItem
+        onClick={() => router.push(`/${locale}/settings/blocked-users`)}
+      >
+        {t("settings.blockedUsers")}
+      </SettingItem>
     </div>
   );
 };

--- a/frontend/src/components/features/social/SocialPostCard/SocialPostCard.tsx
+++ b/frontend/src/components/features/social/SocialPostCard/SocialPostCard.tsx
@@ -86,6 +86,11 @@ interface SocialPostCardProps {
    * 「通報する」項目が表示される。Apple App Review Guideline 1.2 (UGC) 対応。
    */
   onReport?: (postId: string, reason: ReportReason, detail?: string) => void;
+  /**
+   * ユーザーブロック時のハンドラ。指定された場合のみ kebab メニューに「ブロックする」項目が表示される。
+   * 引数の username は確認ダイアログの文言用に親側で利用。Apple App Review Guideline 1.2 (UGC) 対応。
+   */
+  onBlock?: (blockedUserId: string, username: string) => void;
 }
 
 export const SocialPostCard: FC<SocialPostCardProps> = memo(
@@ -96,6 +101,7 @@ export const SocialPostCard: FC<SocialPostCardProps> = memo(
     onFavoriteToggle,
     onClick,
     onReport,
+    onBlock,
   }) {
     const t = useTranslations("socialPosts");
     const locale = useLocale();
@@ -108,7 +114,7 @@ export const SocialPostCard: FC<SocialPostCardProps> = memo(
     const textRef = useRef<HTMLParagraphElement>(null);
     const menuRef = useRef<HTMLDivElement>(null);
     const isOwner = post.user_id === currentUserId;
-    const showMenuButton = !isOwner && !!onReport;
+    const showMenuButton = !isOwner && (!!onReport || !!onBlock);
 
     // ResizeObserverでtruncation検出（layout thrashing回避）
     useEffect(() => {
@@ -224,17 +230,32 @@ export const SocialPostCard: FC<SocialPostCardProps> = memo(
               </Button>
               {showMenu && (
                 <div className={styles.menuDropdown}>
-                  <button
-                    type="button"
-                    className={styles.menuItem}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setShowMenu(false);
-                      setShowReportModal(true);
-                    }}
-                  >
-                    {t("menuReport")}
-                  </button>
+                  {onReport && (
+                    <button
+                      type="button"
+                      className={styles.menuItem}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        setShowReportModal(true);
+                      }}
+                    >
+                      {t("menuReport")}
+                    </button>
+                  )}
+                  {onBlock && (
+                    <button
+                      type="button"
+                      className={styles.menuItem}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        onBlock(post.user_id, post.author.username);
+                      }}
+                    >
+                      {t("menuBlock")}
+                    </button>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.tsx
+++ b/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.tsx
@@ -50,6 +50,11 @@ interface SocialReplyItemProps {
   onDelete: (replyId: string) => Promise<void>;
   onFavoriteToggle: (replyId: string) => void;
   onUnauthenticatedAction?: () => void;
+  /**
+   * 返信投稿者をブロックするハンドラ。指定された場合のみメニューに「ブロックする」項目を追加。
+   * Apple App Review Guideline 1.2 (UGC) 対応。
+   */
+  onBlock?: (blockedUserId: string, username: string) => void;
 }
 
 export const SocialReplyItem: FC<SocialReplyItemProps> = memo(
@@ -62,6 +67,7 @@ export const SocialReplyItem: FC<SocialReplyItemProps> = memo(
     onDelete,
     onFavoriteToggle,
     onUnauthenticatedAction,
+    onBlock,
   }) {
     const t = useTranslations("socialPosts");
     const locale = useLocale();
@@ -213,16 +219,30 @@ export const SocialReplyItem: FC<SocialReplyItemProps> = memo(
                         </button>
                       </>
                     ) : (
-                      <button
-                        type="button"
-                        className={styles.menuItem}
-                        onClick={() => {
-                          setShowMenu(false);
-                          setShowReportModal(true);
-                        }}
-                      >
-                        {t("menuReport")}
-                      </button>
+                      <>
+                        <button
+                          type="button"
+                          className={styles.menuItem}
+                          onClick={() => {
+                            setShowMenu(false);
+                            setShowReportModal(true);
+                          }}
+                        >
+                          {t("menuReport")}
+                        </button>
+                        {onBlock && (
+                          <button
+                            type="button"
+                            className={styles.menuItem}
+                            onClick={() => {
+                              setShowMenu(false);
+                              onBlock(reply.user_id, reply.user.username);
+                            }}
+                          >
+                            {t("menuBlock")}
+                          </button>
+                        )}
+                      </>
                     )}
                   </div>
                 )}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -779,6 +779,46 @@ export interface ReportReplyPayload {
   detail?: string;
 }
 
+export interface BlockedUserListItem {
+  id: string;
+  blocker_user_id: string;
+  blocked_user_id: string;
+  created_at: string;
+  blocked_user: {
+    id: string;
+    username: string;
+    profile_image_url: string | null;
+  };
+}
+
+export const blockUser = async (blockedUserId: string) => {
+  try {
+    return await trpcClient.userBlocks.block.mutate({ blockedUserId });
+  } catch (error) {
+    throw new Error(getErrorMessage(error, "ブロックに失敗しました"));
+  }
+};
+
+export const unblockUser = async (blockedUserId: string) => {
+  try {
+    return await trpcClient.userBlocks.unblock.mutate({ blockedUserId });
+  } catch (error) {
+    throw new Error(getErrorMessage(error, "ブロック解除に失敗しました"));
+  }
+};
+
+export const getBlockedUsers = async (): Promise<BlockedUserListItem[]> => {
+  try {
+    const result = await trpcClient.userBlocks.list.query();
+    if (result?.success && result.data) {
+      return result.data as BlockedUserListItem[];
+    }
+    return [];
+  } catch {
+    return [];
+  }
+};
+
 export const reportReply = async (payload: ReportReplyPayload) => {
   try {
     return await trpcClient.socialReplies.report.mutate(payload);

--- a/frontend/src/server/trpc/procedures.ts
+++ b/frontend/src/server/trpc/procedures.ts
@@ -1053,6 +1053,58 @@ export const reportReplyProcedure = authenticatedProcedure
     );
   });
 
+// ============================================
+// UserBlock (Apple App Review Guideline 1.2)
+// ============================================
+
+export interface BlockedUserListItem {
+  id: string;
+  blocker_user_id: string;
+  blocked_user_id: string;
+  created_at: string;
+  blocked_user: {
+    id: string;
+    username: string;
+    profile_image_url: string | null;
+  };
+}
+
+export const blockUserProcedure = authenticatedProcedure
+  .input(z.object({ blockedUserId: z.string().uuid() }))
+  .mutation(async ({ input, ctx }) => {
+    return callHonoApi<ApiResponse<unknown>>(
+      `/api/social/blocks/${input.blockedUserId}`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${ctx.authToken}` },
+      },
+    );
+  });
+
+export const unblockUserProcedure = authenticatedProcedure
+  .input(z.object({ blockedUserId: z.string().uuid() }))
+  .mutation(async ({ input, ctx }) => {
+    return callHonoApi<ApiResponse<unknown>>(
+      `/api/social/blocks/${input.blockedUserId}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${ctx.authToken}` },
+      },
+    );
+  });
+
+export const getBlockedUsersProcedure = authenticatedProcedure.query(
+  async ({ ctx }) => {
+    return callHonoApi<ApiResponse<BlockedUserListItem[]>>(
+      `/api/social/blocks`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${ctx.authToken}` },
+      },
+    );
+  },
+);
+
 export const toggleReplyFavoriteProcedure = authenticatedProcedure
   .input(
     z.object({

--- a/frontend/src/server/trpc/router.ts
+++ b/frontend/src/server/trpc/router.ts
@@ -1,5 +1,6 @@
 import { createTRPCRouter } from "./index";
 import {
+  blockUserProcedure,
   checkUsernameProcedure,
   createCategoryProcedure,
   createCheckoutSessionProcedure,
@@ -15,6 +16,7 @@ import {
   deletePageProcedure,
   deleteTagProcedure,
   deleteTitleTemplateProcedure,
+  getBlockedUsersProcedure,
   getCategoriesProcedure,
   getDailyLimitsProcedure,
   getNotificationsProcedure,
@@ -52,6 +54,7 @@ import {
   toggleFavoriteProcedure,
   togglePageVisibilityProcedure,
   toggleReplyFavoriteProcedure,
+  unblockUserProcedure,
   updateCategoryProcedure,
   updatePageProcedure,
   updatePublicityDojosProcedure,
@@ -151,6 +154,11 @@ export const appRouter = createTRPCRouter({
     createCheckout: createCheckoutSessionProcedure,
     createPortal: createPortalSessionProcedure,
     sync: syncSubscriptionProcedure,
+  }),
+  userBlocks: createTRPCRouter({
+    block: blockUserProcedure,
+    unblock: unblockUserProcedure,
+    list: getBlockedUsersProcedure,
   }),
 });
 

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -203,7 +203,11 @@
     "saveButton": "Save"
   },
   "settings": {
-    "email": "Email"
+    "email": "Email",
+    "blockedUsers": "Blocked users",
+    "blockedUsersDescription": "Posts from blocked users will not appear in your feed.",
+    "blockedUsersEmpty": "No blocked users",
+    "unblockButton": "Unblock"
   },
   "emailChange": {
     "title": "Email Address",
@@ -772,6 +776,18 @@
     "menuEdit": "Edit",
     "menuDelete": "Delete",
     "menuReport": "Report",
+    "menuBlock": "Block this user",
+    "menuUnblock": "Unblock",
+    "blockConfirmTitle": "Block this user?",
+    "blockConfirmMessage": "Once blocked, you and this user will no longer see each other's posts.",
+    "unblockConfirmTitle": "Unblock this user?",
+    "unblockConfirmMessage": "After unblocking, this user's posts will be visible again.",
+    "blockSuccess": "User blocked",
+    "unblockSuccess": "User unblocked",
+    "blockFailed": "Failed to block user",
+    "unblockFailed": "Failed to unblock user",
+    "blockedProfileMessage": "You have blocked this user",
+    "blockedByTargetMessage": "Posts from this user are not available",
     "postTypeFilter": "Type",
     "filterToggle": "Filter",
     "filterClose": "Close",

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -203,7 +203,11 @@
     "saveButton": "保存する"
   },
   "settings": {
-    "email": "メール"
+    "email": "メール",
+    "blockedUsers": "ブロック中のユーザー",
+    "blockedUsersDescription": "ブロックしたユーザーの投稿はあなたのフィードに表示されなくなります。",
+    "blockedUsersEmpty": "ブロック中のユーザーはいません",
+    "unblockButton": "解除"
   },
   "emailChange": {
     "title": "メールアドレス",
@@ -774,6 +778,18 @@
     "menuEdit": "編集",
     "menuDelete": "削除",
     "menuReport": "通報",
+    "menuBlock": "このユーザーをブロック",
+    "menuUnblock": "ブロックを解除",
+    "blockConfirmTitle": "ユーザーをブロックしますか？",
+    "blockConfirmMessage": "ブロックすると、互いの投稿が表示されなくなります。",
+    "unblockConfirmTitle": "ブロックを解除しますか？",
+    "unblockConfirmMessage": "ブロックを解除すると、相手の投稿が再び表示されるようになります。",
+    "blockSuccess": "ブロックしました",
+    "unblockSuccess": "ブロックを解除しました",
+    "blockFailed": "ブロックに失敗しました",
+    "unblockFailed": "ブロック解除に失敗しました",
+    "blockedProfileMessage": "あなたはこのユーザーをブロックしています",
+    "blockedByTargetMessage": "このユーザーの投稿は表示できません",
     "postTypeFilter": "種類",
     "filterToggle": "絞り込み",
     "filterClose": "閉じる",


### PR DESCRIPTION
## Summary

PR-3a (#295) / PR-3b (#296) で追加した DB / Backend を使う **Frontend 実装** を一括で行います。

これは Apple iOS 版審査リジェクト対応プランの **Phase 3 (PR-3c)** に該当し、Phase 3 の最後の PR です。

## 変更内容

### tRPC + API client
- `userBlocks` を新規 router として追加（`block` / `unblock` / `list` の 3 procedure）
- `frontend/src/lib/api/client.ts` に `blockUser` / `unblockUser` / `getBlockedUsers` を追加（`reportPost` line 767 のスタイル踏襲）
- 型 `BlockedUserListItem` を export

### 投稿カード / 返信からのブロック導線
- `SocialPostCard.tsx` に `onBlock` optional props を追加。kebab メニューに通報の隣に「このユーザーをブロック」項目（`onBlock` がある時のみ表示）
- `SocialReplyItem.tsx` にも `onBlock` 追加（他人の返信時のみ表示）
- 親で `handleUserBlock` を実装:
  - `SocialPostsFeed`: `ConfirmDialog` → `blockUser` → `refetch`
  - `SocialProfileView`: `ConfirmDialog` → `blockUser` → `fetchProfile`
  - `SocialPostDetail`: 返信からのブロックは confirm 省略の即時実行（最小実装）
- `SocialSearchResults` は今回スコープ外（複雑な楽観的更新が必要なため、ブロックメニューを表示しない）

### プロフィール画面のブロック制御
- `ProfileData` 型に `is_blocked` / `is_blocked_by_target` を追加
- 既存メニュー (`SocialProfileView` line 274 周辺) に `!isOwnProfile && isAuthenticated` 時のみ:
  - `is_blocked === true` → 「ブロックを解除」
  - `is_blocked === false` → 「このユーザーをブロック」
- `profile.is_blocked === true` の場合: 投稿リストの代わりに **「あなたはこのユーザーをブロックしています」** プレースホルダ表示
- `profile.is_blocked_by_target === true` の場合: **「このユーザーの投稿は表示できません」**
- ブロック / 解除確認用の `ConfirmDialog` を 2 つ埋め込み

### 設定画面
- `SettingsMenu.tsx` に「ブロック中のユーザー」項目追加
- 新規: `frontend/src/app/[locale]/(authenticated)/settings/blocked-users/page.tsx` (`AuthGate` ラップ)
- 新規: `BlockedUsersSetting.tsx` + `.module.css`
  - `getBlockedUsers` でリスト取得
  - 各行: `ProfileImage` + `username` + 「解除」ボタン
  - 解除時 `ConfirmDialog` → `unblockUser` → 一覧再取得
  - 空状態は `t("settings.blockedUsersEmpty")` で表示

### i18n 新規キー (ja.json / en.json)
**socialPosts:**
- `menuBlock` / `menuUnblock`
- `blockConfirmTitle` / `blockConfirmMessage` / `unblockConfirmTitle` / `unblockConfirmMessage`
- `blockSuccess` / `unblockSuccess` / `blockFailed` / `unblockFailed`
- `blockedProfileMessage` / `blockedByTargetMessage`

**settings:**
- `blockedUsers` / `blockedUsersDescription` / `blockedUsersEmpty` / `unblockButton`

## 動作

1. フィードで他人の投稿 kebab → 「このユーザーをブロック」 → 確認ダイアログ → ブロック → トースト + フィード再取得 (ブロック対象の投稿は backend 側で除外される)
2. プロフィール画面 → ヘッダーメニュー → 「ブロック」 → 確認 → ブロック後はプロフィールから投稿が消えて「あなたはこのユーザーをブロックしています」表示
3. 設定 → 「ブロック中のユーザー」 → リスト表示 → 「解除」ボタン → 確認 → 解除

## 依存

- **PR-3a (#295)** の Supabase 反映済み前提（UserBlock テーブル、get_social_feed 更新）
- **PR-3b (#296)** の backend デプロイ済み前提（`/api/social/blocks` ルート + `getSocialProfile` の `is_blocked` フィールド）

## Test plan

- [x] `pnpm --filter ./frontend exec tsc --noEmit` 通過
- [x] `pnpm check` (errors 0, warnings は既存のもののみ)
- [x] pre-commit 通過
- [ ] PR-3a / PR-3b 反映後に手動動作確認:
  - [ ] 別アカウントから自分の投稿があるフィードで kebab → ブロック → 投稿が消える
  - [ ] プロフィール画面でブロック → 「あなたはこのユーザーをブロックしています」表示 → 投稿が消える
  - [ ] 設定 → ブロック中のユーザー → リスト表示確認 → 「解除」で元通り
  - [ ] ブロックされた側の視点でも投稿が見えなくなることを確認（双方向）

## Related

- 先行: #293 (Phase 1) / #294 (Phase 2) マージ済 / #295 (PR-3a DB) / #296 (PR-3b Backend) レビュー中
- 後続: PR-4 (通報の Slack/Email 通知) → Phase 5 (iOS 再ビルド & 再申請)

🤖 Generated with [Claude Code](https://claude.com/claude-code)