### PR TITLE
feat: ユーザーの通報を受けたら support@aikinote.com へ Email 通知（Apple Guideline 1.2 対応）

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -34,6 +34,8 @@ export type AppBindings = {
   SUPABASE_ANON_KEY?: string;
   JWT_SECRET?: string;
   NEXT_PUBLIC_APP_URL?: string;
+  RESEND_API_KEY?: string;
+  RESEND_FROM_EMAIL?: string;
 };
 
 export type AppVariables = {

--- a/backend/src/lib/report-notification.ts
+++ b/backend/src/lib/report-notification.ts
@@ -1,0 +1,139 @@
+// 通報受領時に運営アドレスへ Email を送る fire-and-forget 通知。
+// Apple App Review Guideline 1.2 (UGC) の「24h 以内に対応」要件を実効性のある運用で満たすため。
+// 既存メールアドレス認証 (backend/src/routes/users/index.ts:178-248) と完全同形式の Resend POST を使用。
+
+const OPS_REPORT_EMAIL = "support@aikinote.com";
+
+const REASON_LABELS: Record<string, string> = {
+  spam: "スパム",
+  harassment: "嫌がらせ",
+  inappropriate: "不適切な内容",
+  impersonation: "なりすまし",
+  other: "その他",
+};
+
+export interface ReportEmailParams {
+  type: "post" | "reply";
+  reportId: string;
+  reason: string;
+  detail: string | null;
+  reporterUsername: string;
+  targetUsername: string;
+  contentSnippet: string;
+  /** 対象投稿/返信を含む詳細ページの URL */
+  targetUrl: string;
+}
+
+export interface ReportEmailEnv {
+  resendApiKey: string | undefined;
+  resendFromEmail: string | undefined;
+}
+
+/**
+ * 運営アドレス (support@aikinote.com) に通報メールを送信する。
+ * - RESEND_API_KEY 未設定時は警告のみで黙ってスキップ（通報自体を失敗させない）
+ * - HTTP 失敗時も例外は投げず console.error のみ
+ */
+export async function notifyReportEmail(
+  params: ReportEmailParams,
+  env: ReportEmailEnv,
+): Promise<void> {
+  if (!env.resendApiKey) {
+    console.warn(
+      "[Report] RESEND_API_KEY 未設定のため通報メールをスキップしました",
+    );
+    return;
+  }
+
+  const fromEmail = env.resendFromEmail || "noreply@example.com";
+  const typeLabel = params.type === "post" ? "投稿" : "返信";
+  const reasonLabel = REASON_LABELS[params.reason] ?? params.reason;
+  const subject = `[AikiNote 通報] ${typeLabel}通報 - ${reasonLabel}`;
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2>新しい${escapeHtml(typeLabel)}通報が届きました</h2>
+      <table style="border-collapse: collapse; width: 100%; margin: 16px 0;">
+        <tr>
+          <th style="text-align: left; padding: 8px; background: #f5f5f5; width: 140px;">通報 ID</th>
+          <td style="padding: 8px; border-bottom: 1px solid #eee;">${escapeHtml(params.reportId)}</td>
+        </tr>
+        <tr>
+          <th style="text-align: left; padding: 8px; background: #f5f5f5;">通報理由</th>
+          <td style="padding: 8px; border-bottom: 1px solid #eee;">${escapeHtml(reasonLabel)}</td>
+        </tr>
+        <tr>
+          <th style="text-align: left; padding: 8px; background: #f5f5f5;">詳細</th>
+          <td style="padding: 8px; border-bottom: 1px solid #eee; white-space: pre-wrap;">${escapeHtml(
+            params.detail ?? "(未入力)",
+          )}</td>
+        </tr>
+        <tr>
+          <th style="text-align: left; padding: 8px; background: #f5f5f5;">通報者</th>
+          <td style="padding: 8px; border-bottom: 1px solid #eee;">${escapeHtml(params.reporterUsername)}</td>
+        </tr>
+        <tr>
+          <th style="text-align: left; padding: 8px; background: #f5f5f5;">対象ユーザー</th>
+          <td style="padding: 8px; border-bottom: 1px solid #eee;">${escapeHtml(params.targetUsername)}</td>
+        </tr>
+        <tr>
+          <th style="text-align: left; padding: 8px; background: #f5f5f5;">対象 URL</th>
+          <td style="padding: 8px; border-bottom: 1px solid #eee;">
+            <a href="${escapeHtml(params.targetUrl)}">${escapeHtml(params.targetUrl)}</a>
+          </td>
+        </tr>
+      </table>
+
+      <h3>本文抜粋</h3>
+      <blockquote style="border-left: 4px solid #ccc; padding: 8px 12px; color: #333; white-space: pre-wrap;">${escapeHtml(
+        params.contentSnippet,
+      )}</blockquote>
+
+      <p style="color: #555; font-size: 13px; margin-top: 24px;">
+        Apple App Review Guideline 1.2 の運用要件として、本通報は受領から
+        <strong>24 時間以内</strong> に確認・対応することを目標としています。
+        Supabase Studio で対象を確認のうえ、不適切と判断したら
+        <code>SocialPost.is_deleted</code>（または <code>SocialReply.is_deleted</code>）を
+        <code>true</code> に、 <code>PostReport.status</code> を
+        <code>resolved</code> に更新してください。
+      </p>
+    </div>
+  `;
+
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: fromEmail,
+        to: [OPS_REPORT_EMAIL],
+        subject,
+        html,
+      }),
+    });
+
+    if (!response.ok) {
+      const responseText = await response.text().catch(() => "");
+      console.error(
+        "[Report] Resend エラー:",
+        response.status,
+        responseText.slice(0, 500),
+      );
+    }
+  } catch (error) {
+    console.error("[Report] Email 通知失敗:", error);
+  }
+}
+
+/** ユーザー入力を HTML テンプレートに埋め込む際の最小エスケープ。 */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/backend/src/routes/social-reports/index.ts
+++ b/backend/src/routes/social-reports/index.ts
@@ -1,17 +1,112 @@
 import { zValidator } from "@hono/zod-validator";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
+import {
+  notifyReportEmail,
+  type ReportEmailParams,
+} from "../../lib/report-notification.js";
 import { createPostReport } from "../../lib/supabase.js";
 import { createReportSchema } from "../../lib/validation.js";
 import { authMiddleware } from "../../middleware/auth.js";
 
 type ReportsBindings = {
   JWT_SECRET?: string;
+  RESEND_API_KEY?: string;
+  RESEND_FROM_EMAIL?: string;
+  NEXT_PUBLIC_APP_URL?: string;
 };
 
 type ReportsVariables = {
   supabase: SupabaseClient | null;
   userId: string;
+};
+
+type ReportsContext = Context<{
+  Bindings: ReportsBindings;
+  Variables: ReportsVariables;
+}>;
+
+const CONTENT_SNIPPET_MAX_LENGTH = 200;
+
+const FALLBACK_BASE_URL = "https://www.aikinote.com";
+
+const getEnv = (
+  c: ReportsContext,
+  key: keyof ReportsBindings,
+): string | undefined =>
+  c.env?.[key] ??
+  (typeof process !== "undefined" ? process.env?.[key] : undefined);
+
+const resolveAppBaseUrl = (c: ReportsContext): string => {
+  const xAppUrl = c.req.header("X-App-Url");
+  if (xAppUrl) return xAppUrl.replace(/\/+$/, "");
+  const envUrl = getEnv(c, "NEXT_PUBLIC_APP_URL");
+  if (envUrl) return envUrl.replace(/\/+$/, "");
+  return FALLBACK_BASE_URL;
+};
+
+const truncate = (value: string, max: number): string =>
+  value.length <= max ? value : `${value.slice(0, max)}…`;
+
+const fetchUsername = async (
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<string> => {
+  const { data } = await supabase
+    .from("User")
+    .select("username")
+    .eq("id", userId)
+    .maybeSingle();
+  return (data?.username as string | undefined) ?? "(不明)";
+};
+
+const fetchPostForReport = async (
+  supabase: SupabaseClient,
+  postId: string,
+): Promise<{ content: string; userId: string }> => {
+  const { data } = await supabase
+    .from("SocialPost")
+    .select("content, user_id")
+    .eq("id", postId)
+    .maybeSingle();
+  return {
+    content: (data?.content as string | undefined) ?? "",
+    userId: (data?.user_id as string | undefined) ?? "",
+  };
+};
+
+const fetchReplyForReport = async (
+  supabase: SupabaseClient,
+  replyId: string,
+): Promise<{ content: string; userId: string; postId: string }> => {
+  const { data } = await supabase
+    .from("SocialReply")
+    .select("content, user_id, post_id")
+    .eq("id", replyId)
+    .maybeSingle();
+  return {
+    content: (data?.content as string | undefined) ?? "",
+    userId: (data?.user_id as string | undefined) ?? "",
+    postId: (data?.post_id as string | undefined) ?? "",
+  };
+};
+
+const queueReportEmail = (
+  c: ReportsContext,
+  params: ReportEmailParams,
+): void => {
+  const env = {
+    resendApiKey: getEnv(c, "RESEND_API_KEY"),
+    resendFromEmail: getEnv(c, "RESEND_FROM_EMAIL"),
+  };
+  // c.executionCtx は Cloudflare Workers Runtime 外（テスト等）では getter が
+  // throw する仕様のため、try/catch で防御。テスト環境では fire-and-forget だが
+  // notifyReportEmail 内部で try/catch しているので unhandled rejection にはならない。
+  try {
+    c.executionCtx.waitUntil(notifyReportEmail(params, env));
+  } catch {
+    void notifyReportEmail(params, env);
+  }
 };
 
 const app = new Hono<{
@@ -42,6 +137,31 @@ app.post(
         reason: input.reason,
         detail: input.detail,
       });
+
+      // 通報受領を運営に Email 通知（fire-and-forget、本体処理は止めない）
+      try {
+        const [reporterUsername, post] = await Promise.all([
+          fetchUsername(supabase, input.user_id),
+          fetchPostForReport(supabase, postId),
+        ]);
+        const targetUsername = post.userId
+          ? await fetchUsername(supabase, post.userId)
+          : "(不明)";
+        const baseUrl = resolveAppBaseUrl(c);
+
+        queueReportEmail(c, {
+          type: "post",
+          reportId: report.id,
+          reason: input.reason,
+          detail: input.detail ?? null,
+          reporterUsername,
+          targetUsername,
+          contentSnippet: truncate(post.content, CONTENT_SNIPPET_MAX_LENGTH),
+          targetUrl: `${baseUrl}/social/posts/${postId}`,
+        });
+      } catch (notifyError) {
+        console.error("[Report] 投稿通報の通知準備でエラー:", notifyError);
+      }
 
       return c.json(
         {
@@ -84,6 +204,34 @@ app.post(
         reason: input.reason,
         detail: input.detail,
       });
+
+      // 通報受領を運営に Email 通知（fire-and-forget、本体処理は止めない）
+      try {
+        const [reporterUsername, reply] = await Promise.all([
+          fetchUsername(supabase, input.user_id),
+          fetchReplyForReport(supabase, replyId),
+        ]);
+        const targetUsername = reply.userId
+          ? await fetchUsername(supabase, reply.userId)
+          : "(不明)";
+        const baseUrl = resolveAppBaseUrl(c);
+        const targetUrl = reply.postId
+          ? `${baseUrl}/social/posts/${reply.postId}#reply-${replyId}`
+          : `${baseUrl}/social/posts/`;
+
+        queueReportEmail(c, {
+          type: "reply",
+          reportId: report.id,
+          reason: input.reason,
+          detail: input.detail ?? null,
+          reporterUsername,
+          targetUsername,
+          contentSnippet: truncate(reply.content, CONTENT_SNIPPET_MAX_LENGTH),
+          targetUrl,
+        });
+      } catch (notifyError) {
+        console.error("[Report] 返信通報の通知準備でエラー:", notifyError);
+      }
 
       return c.json(
         {

--- a/backend/src/routes/social-reports/social-reports.test.ts
+++ b/backend/src/routes/social-reports/social-reports.test.ts
@@ -4,8 +4,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { generateToken } from "../../lib/jwt.js";
 import socialReportsRoute from "./index.js";
 
-const mockSupabase = {} as unknown as SupabaseClient;
+// 通知準備で呼ばれる supabase.from(...).select(...).eq(...).maybeSingle() チェーンをモック化。
+// 既存の通報フローテストでは通知側の値はテスト対象外なので、空チェーンを返すだけで十分。
+const mockFrom = vi.fn().mockImplementation(() => ({
+  select: vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnValue({
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }),
+  }),
+}));
+const mockSupabase = { from: mockFrom } as unknown as SupabaseClient;
 const mockCreatePostReport = vi.fn();
+const mockNotifyReportEmail = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@supabase/supabase-js", () => ({
   createClient: vi.fn(() => mockSupabase),
@@ -13,6 +23,10 @@ vi.mock("@supabase/supabase-js", () => ({
 
 vi.mock("../../lib/supabase.js", () => ({
   createPostReport: (...args: unknown[]) => mockCreatePostReport(...args),
+}));
+
+vi.mock("../../lib/report-notification.js", () => ({
+  notifyReportEmail: (...args: unknown[]) => mockNotifyReportEmail(...args),
 }));
 
 vi.stubEnv("SUPABASE_URL", "https://test.supabase.co");
@@ -102,5 +116,59 @@ describe("投稿通報 POST /api/social-reports/posts/:id", () => {
     // Assert
     expect(res.status).toBe(409);
     expect(body.error).toBe("既に通報済みです");
+    // 重複時は通知も送らない
+    expect(mockNotifyReportEmail).not.toHaveBeenCalled();
+  });
+
+  it("通報成功時に notifyReportEmail が呼ばれる", async () => {
+    // Arrange
+    mockCreatePostReport.mockResolvedValue({ id: "report-1" });
+    const app = createTestApp();
+    const headers = await createAuthHeaders();
+
+    // Act
+    const res = await app.request("/api/social-reports/posts/post-2", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        user_id: TEST_USER_ID,
+        reason: "inappropriate",
+        detail: "テスト詳細",
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(201);
+    expect(mockNotifyReportEmail).toHaveBeenCalledTimes(1);
+    const [params] = mockNotifyReportEmail.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(params.type).toBe("post");
+    expect(params.reportId).toBe("report-1");
+    expect(params.reason).toBe("inappropriate");
+    expect(params.detail).toBe("テスト詳細");
+  });
+
+  it("通知でエラーが起きても通報レスポンスは201で返る", async () => {
+    // Arrange
+    mockCreatePostReport.mockResolvedValue({ id: "report-1" });
+    mockNotifyReportEmail.mockImplementationOnce(() => {
+      throw new Error("Resend down");
+    });
+    const app = createTestApp();
+    const headers = await createAuthHeaders();
+
+    // Act
+    const res = await app.request("/api/social-reports/posts/post-3", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        user_id: TEST_USER_ID,
+        reason: "spam",
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(201);
   });
 });

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -1,0 +1,125 @@
+# 通報インシデント対応運用フロー
+
+このドキュメントは、AikiNote のソーシャル機能における **ユーザー通報 (User-Generated Content reports)** を運営側で対応する手順を定義する。Apple App Review Guideline 1.2 に準拠した「24 時間以内対応」の運用根拠として、再申請時に Reviewer Notes から参照する。
+
+## 概要
+
+AikiNote では、投稿または返信に対する通報が発生したとき、以下の自動・手動オペレーションが連携して動く:
+
+```
+ユーザーが投稿/返信を通報
+   ↓
+Hono Backend (POST /api/social/reports/posts/:id または /replies/:id)
+   ↓ 並列
+   ├── Supabase の PostReport テーブルに行を INSERT (status='pending')
+   └── Resend 経由で運営アドレス (support@aikinote.com) に通知メール送信
+        ↓ メール本文に対象 URL / 通報理由 / 通報者 username / 対象ユーザー username / 本文抜粋を記載
+        ↓
+   運営担当者がメール内のリンクから対象を確認
+        ↓
+   不適切と判断したら Supabase Studio で対応 (24 時間以内)
+        ↓
+   ユーザーに通知 (任意)
+```
+
+## SLA: 24 時間以内対応
+
+通報を受領してから **24 時間以内** に運営担当者は内容を確認し、必要に応じて対象コンテンツの削除または利用者の制限を行うことを目標とする。これは Apple App Review Guideline 1.2 (UGC) で求められる「act on objectionable content reports within 24 hours」要件に対応する。
+
+## 運営側の対応手順
+
+### 1. 通報メールを受信
+
+- 受信先: `support@aikinote.com`
+- 件名形式: `[AikiNote 通報] 投稿通報 - inappropriate` のように種別 + 理由が含まれる
+- 本文には以下が含まれる:
+  - 通報 ID (PostReport.id)
+  - 通報理由 (spam / harassment / inappropriate / impersonation / other)
+  - 通報者の追加詳細 (任意の自由記述、最大 500 字)
+  - 通報者 username
+  - 対象ユーザー username
+  - 対象投稿/返信の URL
+  - 本文抜粋 (200 字まで)
+
+### 2. 対象コンテンツを確認
+
+メール内のリンクから AikiNote 上で対象投稿/返信を実際に開き、コンテンツとコンテキストを確認する。
+
+### 3. 判断と対応
+
+#### 不適切と判断した場合
+
+Supabase Studio で対応:
+
+**投稿の場合:**
+```sql
+UPDATE "SocialPost"
+SET is_deleted = true, updated_at = now()
+WHERE id = '<対象投稿ID>';
+
+UPDATE "PostReport"
+SET status = 'resolved', updated_at = now()
+WHERE id = '<通報ID>';
+```
+
+**返信の場合:**
+```sql
+UPDATE "SocialReply"
+SET is_deleted = true, updated_at = now()
+WHERE id = '<対象返信ID>';
+
+UPDATE "PostReport"
+SET status = 'resolved', updated_at = now()
+WHERE id = '<通報ID>';
+```
+
+繰り返し違反する利用者に対しては、対象アカウントの状態 (`User.publicity_setting` 等) も確認し、必要に応じてアカウント自体に制限を加える。
+
+#### 不適切でないと判断した場合
+
+```sql
+UPDATE "PostReport"
+SET status = 'reviewed', updated_at = now()
+WHERE id = '<通報ID>';
+```
+
+`reviewed` は「通報内容を確認したが、削除には至らなかった」状態。後の追加通報でガイドライン違反パターンが見えた場合の判断材料として残す。
+
+### 4. 対応完了の記録
+
+`PostReport.status` の状態遷移:
+- `pending`: 通報受領直後（デフォルト）
+- `reviewed`: 運営が確認したが削除不要と判断
+- `resolved`: 運営が確認し、対象コンテンツを削除済み
+
+24 時間以内にいずれかの状態に必ず遷移させる。
+
+## 環境変数
+
+通知メールの送信に必要な環境変数 (Cloudflare Workers secret として設定済み):
+
+| 変数 | 説明 |
+|---|---|
+| `RESEND_API_KEY` | Resend API キー（既存メール認証フローと共有） |
+| `RESEND_FROM_EMAIL` | 送信元アドレス（例: `noreply@aikinote.com`） |
+
+通知先アドレス `support@aikinote.com` は `backend/src/lib/report-notification.ts` 内に定数として固定されている。変更時はソース修正が必要。
+
+## Reviewer Notes 用の英文 (Apple 再申請時)
+
+```
+24-hour response commitment
+
+Operations team receives a real-time email notification (sent via Resend to
+support@aikinote.com) on every user report. The notification contains the
+report ID, reason, optional detail, reporter username, target username, the
+URL of the reported content, and a content excerpt.
+
+Upon receiving a notification, the operations team reviews the reported
+content within 24 hours and, if it violates our guidelines, marks the post
+or reply as deleted (`is_deleted = true`) and updates the report status to
+`resolved` in the PostReport table via Supabase Studio.
+
+This procedure satisfies the "act on objectionable content reports within
+24 hours" requirement of App Review Guideline 1.2.
+```


### PR DESCRIPTION
## Summary

Apple App Review Guideline 1.2 (UGC) で求められる **「24h 以内に objectionable content reports に対応する」** 要件を運用面でも担保するため、通報 POST 成功直後に **fire-and-forget で運営アドレス `support@aikinote.com` へメール通知** を送る仕組みを追加します。

これは Apple iOS 版審査リジェクト対応プランの **Phase 4 (PR-4)** に該当します。

## 変更内容

### `lib/report-notification.ts` 新規
- 通知先 `OPS_REPORT_EMAIL = "support@aikinote.com"` を定数で固定
- `notifyReportEmail(params, env)`:
  - `RESEND_API_KEY` 未設定時は `console.warn` のみで黙ってスキップ（通報自体を失敗させない）
  - Resend POST 失敗時も例外は投げず `console.error` のみ
- 既存メール認証フロー (`backend/src/routes/users/index.ts:178-248`) と同形式の `fetch("https://api.resend.com/emails")` を使用
- HTML テーブルで通報 ID / 理由 / 詳細 / 通報者 / 対象ユーザー / 対象 URL / 本文抜粋を整形
- `escapeHtml` で username / detail / contentSnippet の XSS を防御

### `routes/social-reports/index.ts`
- 投稿通報 / 返信通報の `createPostReport` 成功直後に通知準備:
  1. 報告者 username + 対象投稿/返信の content / user_id を `Promise.all` で並列取得
  2. 対象投稿者 username を取得（FK が `auth.users` を参照しているため 2 段階クエリ）
  3. `X-App-Url` ヘッダーを最優先に baseUrl を解決し `targetUrl` を組み立て
  4. `c.executionCtx.waitUntil(notifyReportEmail(...))` で fire-and-forget
  5. test 環境では `try/catch` でフォールバック（`social-posts/index.ts:300-304` のパターン踏襲）
- 通知準備でエラーが起きても通報レスポンスは **201 で返す**（本体処理は止めない）

### `app.ts` の `AppBindings` 型
- `RESEND_API_KEY?: string` / `RESEND_FROM_EMAIL?: string` を追加（既存環境変数を流用）

### テスト (backend 220/220 グリーン)
既存 3 ケース + 新規 2 ケース:
- 通報成功時に `notifyReportEmail` がコールされ、`type` / `reportId` / `reason` / `detail` が正しく渡る
- 通知でエラーが起きても通報レスポンスは 201 で返る
- 重複通報 (409) 時は通知も送らない

### `docs/incident-response.md` 新規
- 通報メールから Supabase Studio での対応までの運用フロー
- `PostReport.status` の状態遷移 (`pending` → `reviewed` / `resolved`)
- Reviewer Notes 用の英文版（Apple 再申請時に使う）

## 環境変数

`RESEND_API_KEY` / `RESEND_FROM_EMAIL` は既存メール認証で使用中のため Cloudflare Workers secret として **既に本番環境に設定済み**。新規環境変数は不要。

## Test plan

- [x] `pnpm vitest run src/routes/social-reports/social-reports.test.ts` (5/5 グリーン)
- [x] `pnpm test` 全体 (backend 220/220 + frontend 276/276 グリーン)
- [x] `pnpm --filter ./backend exec tsc --noEmit` 通過
- [x] `pnpm check` (errors 0、warnings は既存のもののみ)
- [x] pre-commit フック通過
- [ ] マージ後 + 本番デプロイ後に手動確認:
  - [ ] テスト用アカウントで自分の投稿に別アカウントから通報 → `support@aikinote.com` に通報メールが届くこと
  - [ ] メール内の対象 URL リンクから対象投稿が開けること
  - [ ] 通報送信時のレスポンスが 201 であること
  - [ ] Resend のダッシュボードで送信ログを確認

## Related

- 先行: #293 (Phase 1) / #294 (Phase 2) / #295/#296/#297 (Phase 3) すべてマージ済 + 動作確認済
- 後続: **Phase 5** iOS 再ビルド + App Store Connect 再提出 (Reviewer Notes に本実装を記載)

🤖 Generated with [Claude Code](https://claude.com/claude-code)