### PR TITLE
fix: 投稿検索の履歴保存とインクリメンタルサーチのローディング UX を改善

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearch.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearch.tsx
@@ -90,11 +90,9 @@ const SocialSearchBar = memo(
       [onSearch, onQueryActiveChange],
     );
 
-    const handleKeyDown = useCallback(
-      (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter") {
-          onSubmit(queryRef.current);
-        }
+    const handleSubmit = useCallback(
+      (value: string) => {
+        onSubmit(value);
       },
       [onSubmit],
     );
@@ -110,7 +108,7 @@ const SocialSearchBar = memo(
       <SearchInput
         value={query}
         onChange={handleChange}
-        onKeyDown={handleKeyDown}
+        onSubmit={handleSubmit}
         onClear={handleClear}
         placeholder={placeholder}
       />

--- a/frontend/src/components/shared/SearchInput/SearchInput.module.css
+++ b/frontend/src/components/shared/SearchInput/SearchInput.module.css
@@ -2,6 +2,8 @@
   position: relative;
   display: flex;
   align-items: center;
+  margin: 0;
+  width: 100%;
 }
 
 .searchIcon {
@@ -54,4 +56,11 @@
 .searchInput:focus {
   border-color: var(--primary-color);
   background-color: var(--white);
+}
+
+/* type="search" のブラウザ標準クリアボタンを非表示（独自 clearButton を使うため） */
+.searchInput::-webkit-search-cancel-button,
+.searchInput::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
 }

--- a/frontend/src/components/shared/SearchInput/SearchInput.test.tsx
+++ b/frontend/src/components/shared/SearchInput/SearchInput.test.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SearchInput } from "./SearchInput";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => {
+    const dict: Record<string, string> = {
+      "components.searchPlaceholder": "キーワードで検索",
+      "components.clear": "クリア",
+    };
+    return dict[key] ?? key;
+  },
+}));
+
+describe("SearchInput", () => {
+  it("input が type='search' で enterKeyHint='search' / inputMode='search' を持つ", () => {
+    // Arrange / Act
+    render(<SearchInput value="" onChange={() => {}} />);
+    const input = screen.getByRole("searchbox") as HTMLInputElement;
+
+    // Assert
+    expect(input.type).toBe("search");
+    expect(input.getAttribute("enterKeyHint")).toBe("search");
+    expect(input.getAttribute("inputMode")).toBe("search");
+  });
+
+  it("form の submit イベントで onSubmit が現在の value で呼ばれる", () => {
+    // Arrange
+    const handleSubmit = vi.fn();
+    const { container } = render(
+      <SearchInput
+        value="合気道"
+        onChange={() => {}}
+        onSubmit={handleSubmit}
+      />,
+    );
+    const form = container.querySelector("form");
+    expect(form).not.toBeNull();
+
+    // Act
+    if (form) fireEvent.submit(form);
+
+    // Assert
+    expect(handleSubmit).toHaveBeenCalledWith("合気道");
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter キー押下（IME 確定外）で form submit が発火し onSubmit が呼ばれる", async () => {
+    // Arrange
+    const handleSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SearchInput
+        value="検索クエリ"
+        onChange={() => {}}
+        onSubmit={handleSubmit}
+      />,
+    );
+    const input = screen.getByRole("searchbox");
+
+    // Act
+    await user.click(input);
+    await user.keyboard("{Enter}");
+
+    // Assert
+    expect(handleSubmit).toHaveBeenCalledWith("検索クエリ");
+  });
+
+  it("IME 変換確定中（keyCode 229）の Enter では onSubmit が呼ばれない", () => {
+    // Arrange
+    const handleSubmit = vi.fn();
+    render(
+      <SearchInput
+        value="あいき"
+        onChange={() => {}}
+        onSubmit={handleSubmit}
+      />,
+    );
+    const input = screen.getByRole("searchbox");
+
+    // Act
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      keyCode: 229,
+      isComposing: true,
+    });
+
+    // Assert
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it("値があるとクリアボタンが表示され、押下で onClear が呼ばれる", async () => {
+    // Arrange
+    const handleClear = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SearchInput value="text" onChange={() => {}} onClear={handleClear} />,
+    );
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "クリア" }));
+
+    // Assert
+    expect(handleClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("値が空のときはクリアボタンが表示されない", () => {
+    // Arrange / Act
+    render(<SearchInput value="" onChange={() => {}} onClear={() => {}} />);
+
+    // Assert
+    expect(
+      screen.queryByRole("button", { name: "クリア" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("後方互換: onKeyDown プロップが渡されていれば従来通り keydown で呼ばれる", () => {
+    // Arrange
+    const handleKeyDown = vi.fn();
+    render(
+      <SearchInput value="" onChange={() => {}} onKeyDown={handleKeyDown} />,
+    );
+    const input = screen.getByRole("searchbox");
+
+    // Act
+    fireEvent.keyDown(input, { key: "a" });
+
+    // Assert
+    expect(handleKeyDown).toHaveBeenCalled();
+  });
+
+  it("IME 確定中の Enter では onKeyDown は早期リターンされ呼ばれない", () => {
+    // Arrange
+    const handleKeyDown = vi.fn();
+    render(
+      <SearchInput value="" onChange={() => {}} onKeyDown={handleKeyDown} />,
+    );
+    const input = screen.getByRole("searchbox");
+
+    // Act
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      keyCode: 229,
+      isComposing: true,
+    });
+
+    // Assert
+    expect(handleKeyDown).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/shared/SearchInput/SearchInput.tsx
+++ b/frontend/src/components/shared/SearchInput/SearchInput.tsx
@@ -1,11 +1,23 @@
 import { MagnifyingGlassIcon, XCircleIcon } from "@phosphor-icons/react";
 import { useTranslations } from "next-intl";
-import type { ChangeEvent, FC, KeyboardEvent } from "react";
+import {
+  type ChangeEvent,
+  type FC,
+  type FormEvent,
+  type KeyboardEvent,
+  useCallback,
+} from "react";
 import styles from "./SearchInput.module.css";
 
 interface SearchInputProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  /**
+   * 確定操作（Enter / ソフトキーボード「検索」ボタン / form submit）で発火。
+   * IME 変換確定中は呼ばれない。
+   */
+  onSubmit?: (value: string) => void;
+  /** 後方互換のために残置。新規実装は onSubmit を使うこと。 */
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   onClear?: () => void;
   placeholder?: string;
@@ -14,6 +26,7 @@ interface SearchInputProps {
 export const SearchInput: FC<SearchInputProps> = ({
   value,
   onChange,
+  onSubmit,
   onKeyDown,
   onClear,
   placeholder,
@@ -21,8 +34,38 @@ export const SearchInput: FC<SearchInputProps> = ({
   const t = useTranslations();
   const defaultPlaceholder = placeholder || t("components.searchPlaceholder");
   const showClear = value.length > 0 && onClear;
+
+  const handleFormSubmit = useCallback(
+    (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      onSubmit?.(value);
+    },
+    [onSubmit, value],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      // IME 変換確定中の Enter は form の暗黙 submit を抑止
+      if (
+        e.key === "Enter" &&
+        (e.nativeEvent.isComposing || e.keyCode === 229)
+      ) {
+        e.preventDefault();
+        return;
+      }
+      onKeyDown?.(e);
+    },
+    [onKeyDown],
+  );
+
   return (
-    <div className={styles.searchBox}>
+    // biome-ignore lint/a11y/useSemanticElements: <search> 要素で <form> を包むと flex レイアウト再構築が必要なため、role 属性で代替
+    <form
+      className={styles.searchBox}
+      onSubmit={handleFormSubmit}
+      role="search"
+      action="#"
+    >
       <MagnifyingGlassIcon
         size={14}
         weight="light"
@@ -30,11 +73,17 @@ export const SearchInput: FC<SearchInputProps> = ({
         className={styles.searchIcon}
       />
       <input
-        type="text"
+        type="search"
         placeholder={defaultPlaceholder}
         value={value}
         onChange={onChange}
-        onKeyDown={onKeyDown}
+        onKeyDown={handleKeyDown}
+        inputMode="search"
+        enterKeyHint="search"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
         className={`${styles.searchInput} ${showClear ? styles.searchInputWithClear : ""}`}
       />
       {showClear && (
@@ -47,6 +96,6 @@ export const SearchInput: FC<SearchInputProps> = ({
           <XCircleIcon size={18} weight="fill" />
         </button>
       )}
-    </div>
+    </form>
   );
 };

--- a/frontend/src/lib/hooks/useSocialSearch.ts
+++ b/frontend/src/lib/hooks/useSocialSearch.ts
@@ -1,6 +1,10 @@
 "use client";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import type { SocialFeedPostData } from "@/components/features/social/SocialPostCard/SocialPostCard";
 import {
@@ -19,7 +23,10 @@ interface SearchInput {
 
 interface UseSocialSearchResult {
   results: SocialFeedPostData[];
+  /** 初回ロード中（前回結果が無い状態でフェッチ中）。大きな Loader 表示用 */
   isLoading: boolean;
+  /** バックグラウンドフェッチ中（前回結果あり、新クエリ実行中）。subtle インジケータ用 */
+  isFetching: boolean;
   search: (
     query: string,
     dojoName?: string,
@@ -80,6 +87,9 @@ export function useSocialSearch(
         ? (result.data as SocialFeedPostData[])
         : [];
     },
+    // 検索条件が変わっても前回の結果リストを保持し、入力中に大きな Loader が
+    // 出て画面が空になる UX 悪化を防ぐ
+    placeholderData: keepPreviousData,
   });
 
   const search = useCallback(
@@ -117,7 +127,8 @@ export function useSocialSearch(
 
   return {
     results: enabled ? (query.data ?? []) : [],
-    isLoading: enabled && (query.isLoading || query.isFetching),
+    isLoading: enabled && query.isLoading,
+    isFetching: enabled && query.isFetching && !query.isLoading,
     search,
     updateResult,
   };


### PR DESCRIPTION
## Summary

- **不具合 1（SP / ネイティブで履歴が残らない）**: 投稿検索バーの `<input>` が `<form>` でラップされていなかったため、SP のソフトキーボードでは Enter `keydown` が確実発火せず、履歴追加トリガーが走らなかった問題を修正
- **不具合 2（インクリメンタルサーチで Loader が画面を覆う）**: 入力するたびに結果リストが空配列にリセットされ、大きな Loader が画面中央に表示される UX 問題を、TanStack Query の `placeholderData: keepPreviousData` で前回結果を保持することで解消
- **テスト追加**: `SearchInput.test.tsx` を新規作成（8 ケース、AAA パターン）

## 背景

| 環境 | 履歴保存（修正前） | 履歴保存（修正後） |
|---|---|---|
| PC ブラウザ | 正常 | 正常 |
| スマホブラウザ（iOS Safari / Android Chrome） | **保存されない** | 正常 |
| iOS / Android ネイティブアプリ | **保存されない** | 正常（連動） |

ネイティブアプリは Web 版を WebView で表示し、`localStorage.setItem('aikinote_search_history', ...)` をフックして AsyncStorage に同期する設計。**Web 側で `setItem` が走らないと、ネイティブも履歴が保存されない**ため、Web 修正で連動して直る。

## 変更点

### `frontend/src/components/shared/SearchInput/SearchInput.tsx`
- `<form onSubmit>` でラップ、HTML 標準の暗黙 submit を活用
- `type="search"` + `enterKeyHint="search"` + `inputMode="search"` でモバイルキーボードを検索向けに最適化
- `e.nativeEvent.isComposing || e.keyCode === 229` で IME 変換確定中の Enter を早期リターン
- `onSubmit` プロップを追加。`onKeyDown` は後方互換のため残置
- `autoComplete/autoCorrect/autoCapitalize/spellCheck` で日本語検索の意図しない補正を抑止
- `role="search"` + `action="#"` で a11y / iOS Safari 互換性を確保

### `frontend/src/components/shared/SearchInput/SearchInput.module.css`
- `.searchBox` に `margin: 0; width: 100%` を追加（`<form>` 化に伴うリセット）
- `::-webkit-search-cancel-button` 等のブラウザ標準クリアボタンを非表示

### `frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearch.tsx`
- `SocialSearchBar` の `handleKeyDown` を削除し、`handleSubmit` に置換
- `SearchInput` への props を `onKeyDown` から `onSubmit` に変更

### `frontend/src/lib/hooks/useSocialSearch.ts`
- `placeholderData: keepPreviousData` を追加し、新クエリ実行中も前回結果を保持
- `isLoading` を初回ロード時のみ（`query.isLoading`）に限定
- `isFetching` を新規追加（バックグラウンド更新中のフラグ、subtle インジケータ用）

### `frontend/src/components/shared/SearchInput/SearchInput.test.tsx`（新規）
8 ケース（AAA パターン）:
1. `type='search'` / `enterKeyHint='search'` / `inputMode='search'` 属性の確認
2. form の submit イベントで `onSubmit` が呼ばれる
3. Enter キー押下で form submit が発火し `onSubmit` が呼ばれる
4. IME 変換確定中（`keyCode 229`）の Enter で `onSubmit` が呼ばれない
5. 値があるとクリアボタンが表示され、押下で `onClear` が呼ばれる
6. 値が空のときはクリアボタンが表示されない
7. 後方互換: `onKeyDown` プロップが渡されていれば従来通り keydown で呼ばれる
8. IME 確定中の Enter では `onKeyDown` も早期リターンで呼ばれない

## Test plan

### 自動テスト（実施済み）
- [x] `pnpm vitest run src/components/shared/SearchInput/SearchInput.test.tsx`: **8 passed**
- [x] `pnpm check`: 0 errors（既存の 9 warnings は今回の変更と無関係）
- [x] `pnpm tsc --noEmit`: exit 0

### 実機動作確認（要レビュー）

**PC ブラウザ（リグレッション）**
- [ ] Chrome / Safari で `/social/posts/search` を開き、「合気道」と入力 → Enter → 結果表示・履歴に追加
- [ ] 続けて「四方投げ」入力 → Enter → 履歴の先頭が「四方投げ」、次が「合気道」
- [ ] DevTools → Application → Local Storage で `aikinote_search_history` が UI と一致

**インクリメンタルサーチの UX**
- [ ] 「合気」と入力 → 結果表示後、続けて「合気道」と入力したとき、結果リストが瞬間的に消えず、前回結果が表示され続け、新結果到着で滑らかに差し替わる（中央の大きな Loader は出ない）

**iOS Safari（実機）**
- [ ] ソフトキーボード右下が「検索」ボタンになる
- [ ] 「合気道」と日本語入力 → 変換確定 → 「検索」ボタンタップ → 結果表示・履歴に追加

**Android Chrome（実機）**
- [ ] GBoard で「あいきどう」入力 → 変換候補から確定 → ここでは履歴追加されない（IME ガード動作確認）
- [ ] 確定後にもう一度 Enter → 検索実行・履歴追加

**iOS / Android ネイティブアプリ**
- [ ] 「合気道」入力 → 「検索」ボタンタップ → 履歴追加
- [ ] アプリをタスクキル → 再起動 → 履歴に「合気道」が残っている（AsyncStorage から復元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)