### PR TITLE
feat: TanStack Query の活用度を向上（検索無限スクロール / Optimistic / DevTools 等）

### DIFF
--- a/frontend/docs/tanstack-query-patterns.md
+++ b/frontend/docs/tanstack-query-patterns.md
@@ -1,0 +1,166 @@
+# TanStack Query 採用パターン早見表
+
+AikiNote Web で TanStack Query (React Query) v5 を使う際の判断基準と実装パターンをまとめたものです。新規実装・既存改修時はこのドキュメントを参照してください。
+
+## 1. データ取得 API の選び分け
+
+| API | 用途 | 主な使用例 |
+|---|---|---|
+| `useQuery` | 単発の取得・enabled で条件制御 | 認証済みユーザー情報、設定、単一エンティティ取得 |
+| `useInfiniteQuery` | ページ送り・無限スクロール・タブ切替で page 蓄積 | 投稿フィード、稽古ノート一覧、通知、検索結果 |
+| `useMutation` | サーバ更新（POST/PATCH/DELETE）+ 楽観的更新 | 投稿作成、削除、編集、いいね、フォロー |
+
+## 2. Query Key Factory パターン（必須）
+
+**ルール**: 各 hook ファイルで queryKey を生成する関数を `as const` 付きで `export` し、複数箇所からの参照に対応する。
+
+```ts
+export const socialFeedQueryKey = (
+  userId: string | undefined,
+  tab: SocialTab,
+) => ["social-feed", userId, tab] as const;
+```
+
+**理由**:
+- キャッシュ無効化（`queryClient.invalidateQueries({ queryKey: socialFeedQueryKey(...) })`）で型安全性が得られる
+- 別ファイルからの cross-cache 操作（`setQueryData`, `setQueriesData`）が可能になる
+- キー構造変更時の影響範囲が hook ファイルに局所化される
+
+## 3. 楽観的更新の方針：`useOptimistic` と `setQueryData` の使い分け
+
+### `useOptimistic` (React 19) を使う条件
+- **単一画面・単一 component で完結する**操作
+- form action / `startTransition` 内で `addOptimistic` を呼べる構造
+- 例: 詳細画面内の reply 編集（`SocialPostDetail.tsx`）
+
+```tsx
+const [optimisticReplies, addOptimisticReply] = useOptimistic(
+  detail?.replies ?? [],
+  (state, edit: { id: string; content: string }) =>
+    state.map((r) => (r.id === edit.id ? { ...r, content: edit.content } : r)),
+);
+const [, startReplyEditTransition] = useTransition();
+
+const handleEdit = (replyId, newContent) => {
+  startReplyEditTransition(async () => {
+    addOptimisticReply({ id: replyId, content: newContent });
+    await updateReply(...);
+    setRealState(...);
+  });
+};
+```
+
+**メリット**: transition 終了時に自動ロールバック、宣言的、コードが短い
+**注意**: `addOptimistic` は transition 内でのみ有効。外で呼ぶとエラー
+
+### `setQueryData` を使う条件（`useOptimistic` を使わない）
+- **複数キャッシュ横断**での更新が必要（例: フィード 3 タブ + 検索結果 + 詳細を同時更新）
+- `useMutation` の `onMutate` / `onError` / `onSettled` でロールバック制御が必要
+- persist client (localStorage) の整合性を直接保ちたい
+
+例: いいねトグル (`useSocialFavorite.ts`)、稽古ノート削除 (`useTrainingPagesData.ts`)、投稿フィード `updatePost` (`useSocialFeed.ts`)
+
+```tsx
+queryClient.setQueriesData<InfiniteData<SocialFeedPage>>(
+  { queryKey: socialFeedQueryKey(user?.id, t) },
+  (old) =>
+    old
+      ? {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            posts: page.posts.map((p) =>
+              p.id === postId ? updater(p) : p,
+            ),
+          })),
+        }
+      : old,
+);
+```
+
+**判断フロー**:
+```
+楽観的更新が必要？
+├─ Yes
+│   ├─ 1 component / 1 cache で完結する？
+│   │   ├─ Yes → useOptimistic を使う
+│   │   └─ No → setQueryData / setQueriesData を使う
+│   └─ persist 対象キーの整合を保ちたい？ → setQueryData を使う
+└─ No → 通常の useMutation + invalidateQueries
+```
+
+## 4. `select` オプションの活用
+
+**ルール**: `useInfiniteQuery` で `data.pages.flatMap(...)` のような派生データが必要な場合、外側の `useMemo` ではなく `select` オプションを使う。
+
+```ts
+const query = useInfiniteQuery<TPage, Error, FlatItem[], TKey, number>({
+  queryKey: ...,
+  queryFn: ...,
+  getNextPageParam: ...,
+  // structural sharing により同一データなら同一参照が返り、Component 再レンダ時の
+  // 再計算を抑制（useMemo より効率的）
+  select: (data) => data.pages.flatMap((p) => p.items),
+});
+
+const items = query.data ?? [];
+```
+
+**理由**: `select` は TanStack Query の structural sharing を利用するため、同じ query 結果なら同じ参照を返す。`useMemo` は dependency 比較のみで参照同一性は保証しない。
+
+## 5. `placeholderData: keepPreviousData` の使い所
+
+検索・フィルタ変更時に「画面が一瞬空になる」UX 悪化を防ぐ。新 queryKey 取得中も旧 page を表示し続ける。
+
+```ts
+import { keepPreviousData } from "@tanstack/react-query";
+
+useInfiniteQuery({
+  queryKey: socialSearchQueryKey(userId, debouncedInput),
+  ...,
+  placeholderData: keepPreviousData,
+});
+```
+
+`isFetching && !isLoading` で「バックグラウンド更新中」のサブインジケータを出すと、ユーザーが新結果を待っていることを示せる。
+
+## 6. localStorage 永続化と除外条件
+
+`PersistQueryClientProvider` (`QueryProvider.tsx`) で全 query を localStorage に persist しているが、容量上限（5MB 前後）を圧迫しないため以下を除外：
+
+```ts
+shouldDehydrateQuery: (query) =>
+  query.state.status === "success" &&
+  Boolean(query.state.data) &&
+  query.queryKey[0] !== "social-search",
+```
+
+**除外候補の判断**:
+- 検索結果のように page が無限に積み重なるもの → 除外
+- 認証セッションに紐付くが揮発しても問題ないもの → 除外
+- 高頻度更新で persist するメリットが薄いもの → 除外
+
+## 7. グローバル fetch インジケータ
+
+`GlobalFetchIndicator` (`components/shared/GlobalFetchIndicator/`) が `useIsFetching()` で全クエリの fetch 数を監視し、上端に薄い 2px プログレスバーを表示する。
+
+個別画面で大きな Loader を出さなくても、ユーザーは「何か取得中」と認識できる。バックグラウンド refetch も対象。
+
+## 8. DevTools
+
+開発時のみ `@tanstack/react-query-devtools` のフローティングボタンが画面右下に表示される（`QueryProvider.tsx` 内で `process.env.NODE_ENV !== "production"` 条件で `next/dynamic` 経由 lazy import）。
+
+**localStorage persistor との注意点**: Devtools の "Remove from cache" は localStorage を直接書き換えない。整合を取りたい場合は手動で `localStorage.clear()` または該当キー削除。
+
+## 9. 既存実装の参照ポイント
+
+| 実装パターン | ファイル |
+|---|---|
+| `useInfiniteQuery` 基本形 | `frontend/src/lib/hooks/useSocialFeed.ts` |
+| `useInfiniteQuery` + 検索 + `keepPreviousData` | `frontend/src/lib/hooks/useSocialSearch.ts` |
+| `useMutation` + 楽観的削除 + ロールバック | `frontend/src/lib/hooks/useTrainingPagesData.ts` |
+| cross-cache 更新 (`updatePost`) | `frontend/src/lib/hooks/useSocialFeed.ts` の `updatePost` / `useRemoveFromSocialFeedCache` |
+| polling | `frontend/src/lib/hooks/useUnreadNotificationCount.ts` |
+| IntersectionObserver sentinel | `frontend/src/app/[locale]/(authenticated)/(tabbed)/social/posts/SocialPostsFeed.tsx` |
+| `useOptimistic` + `useTransition` | `frontend/src/app/[locale]/(public)/social/posts/[post_id]/SocialPostDetail.tsx` の `handleReplyEdit` |
+| prefetchInfiniteQuery (タブ先読み) | `frontend/src/lib/hooks/useSocialFeed.ts` の `useEffect` 内 |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "@biomejs/biome": "^2.1.4",
     "@storybook/addon-a11y": "^9.1.20",
     "@storybook/nextjs-vite": "^9.1.14",
+    "@tanstack/react-query-devtools": "^5.99.2",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearch.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearch.module.css
@@ -158,6 +158,19 @@
   font-size: var(--font-size-sm);
 }
 
+.sentinel {
+  padding: 20px 0;
+  display: flex;
+  justify-content: center;
+}
+
+.endMessage {
+  padding: 20px 0;
+  text-align: center;
+  color: var(--text-light);
+  font-size: var(--font-size-xs);
+}
+
 /* 検索履歴セクション */
 .historySection {
   padding: 16px;

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearchResults.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/search/SocialSearchResults.tsx
@@ -6,7 +6,13 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { useTranslations } from "next-intl";
-import { forwardRef, useCallback, useImperativeHandle } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
 import { SocialPostCard } from "@/components/features/social/SocialPostCard/SocialPostCard";
 import { Button } from "@/components/shared/Button/Button";
 import { Loader } from "@/components/shared/Loader/Loader";
@@ -56,7 +62,15 @@ export const SocialSearchResults = forwardRef<
   const t = useTranslations("socialPosts");
   const router = useRouter();
   const { showToast } = useToast();
-  const { results, isLoading, search, updateResult } = useSocialSearch(userId);
+  const {
+    results,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    loadMore,
+    search,
+    updateResult,
+  } = useSocialSearch(userId);
   const { handleToggleFavorite } = useSocialFavorite();
   const { history, addToHistory, removeFromHistory, clearHistory } =
     useSearchHistory();
@@ -70,6 +84,45 @@ export const SocialSearchResults = forwardRef<
     }),
     [search, addToHistory],
   );
+
+  // IntersectionObserver で無限スクロール。SocialPostsFeed と同じ ref-based パターン：
+  // 値の変化で observer を再生成すると検索条件変更時に取りこぼしが起きるため、
+  // loadMore / hasMore / isLoadingMore は ref 経由で参照し、observer は sentinel ノードのマウント時にのみ生成する
+  const loadMoreRef = useRef(loadMore);
+  loadMoreRef.current = loadMore;
+  const hasMoreRef = useRef(hasMore);
+  hasMoreRef.current = hasMore;
+  const isLoadingMoreRef = useRef(isLoadingMore);
+  isLoadingMoreRef.current = isLoadingMore;
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const setSentinelRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (
+          entries[0].isIntersecting &&
+          hasMoreRef.current &&
+          !isLoadingMoreRef.current
+        ) {
+          loadMoreRef.current();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+    };
+  }, []);
 
   const handleFavoriteToggle = useCallback(
     (postId: string) => {
@@ -232,16 +285,21 @@ export const SocialSearchResults = forwardRef<
       ) : isSearchActive && results.length === 0 ? (
         <p className={styles.empty}>{t("searchEmpty")}</p>
       ) : (
-        results.map((post) => (
-          <SocialPostCard
-            key={post.id}
-            post={post}
-            currentUserId={userId ?? ""}
-            onFavoriteToggle={handleFavoriteToggle}
-            onClick={handlePostClick}
-            onReport={handlePostReport}
-          />
-        ))
+        <>
+          {results.map((post) => (
+            <SocialPostCard
+              key={post.id}
+              post={post}
+              currentUserId={userId ?? ""}
+              onFavoriteToggle={handleFavoriteToggle}
+              onClick={handlePostClick}
+              onReport={handlePostReport}
+            />
+          ))}
+          <div ref={setSentinelRef} className={styles.sentinel}>
+            {isLoadingMore && <Loader size="large" centered />}
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/app/[locale]/(public)/social/posts/[post_id]/SocialPostDetail.tsx
+++ b/frontend/src/app/[locale]/(public)/social/posts/[post_id]/SocialPostDetail.tsx
@@ -7,7 +7,14 @@ import {
 } from "@phosphor-icons/react";
 import dynamic from "next/dynamic";
 import { useLocale, useTranslations } from "next-intl";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 
 const ReportModal = dynamic(
   () =>
@@ -350,26 +357,47 @@ export function SocialPostDetail({ postId }: SocialPostDetailProps) {
     [user?.id, showToast, t],
   );
 
+  // reply 編集の楽観的更新。useOptimistic は startTransition の中で addOptimisticReply を呼んだ時のみ
+  // 適用され、transition 終了時 (await mutation 完了) に real state (detail.replies) に自動で戻る。
+  // 失敗ケースは showToast で通知し、optimistic state は transition 終了で自動ロールバックされる。
+  const [optimisticReplies, addOptimisticReply] = useOptimistic(
+    detail?.replies ?? [],
+    (state: SocialReplyData[], edit: { id: string; content: string }) =>
+      state.map((r) =>
+        r.id === edit.id ? { ...r, content: edit.content } : r,
+      ),
+  );
+  const [, startReplyEditTransition] = useTransition();
+
   const handleReplyEdit = useCallback(
-    async (replyId: string, newContent: string) => {
-      try {
-        const editResult = await updateSocialReply({
-          postId,
-          replyId,
-          content: newContent,
+    (replyId: string, newContent: string): Promise<void> => {
+      // SocialReplyItem 側で await して編集 UI の閉じタイミング・処理中表示を制御するため、
+      // transition 完了を Promise で外に解決する形にする
+      return new Promise<void>((resolve) => {
+        startReplyEditTransition(async () => {
+          addOptimisticReply({ id: replyId, content: newContent });
+          try {
+            const editResult = await updateSocialReply({
+              postId,
+              replyId,
+              content: newContent,
+            });
+            if (editResult.success && editResult.warning) {
+              showToast(editResult.warning, "error");
+            }
+            const result = await getSocialPost(postId);
+            if (result.success && result.data) {
+              setDetail(result.data as PostDetailData);
+            }
+          } catch {
+            showToast(t("replyEditFailed"), "error");
+          } finally {
+            resolve();
+          }
         });
-        if (editResult.success && editResult.warning) {
-          showToast(editResult.warning, "error");
-        }
-        const result = await getSocialPost(postId);
-        if (result.success && result.data) {
-          setDetail(result.data as PostDetailData);
-        }
-      } catch {
-        showToast(t("replyEditFailed"), "error");
-      }
+      });
     },
-    [postId, showToast, t],
+    [postId, showToast, t, addOptimisticReply],
   );
 
   const handleReplyDelete = useCallback(
@@ -683,7 +711,7 @@ export function SocialPostDetail({ postId }: SocialPostDetailProps) {
       </div>
 
       <div className={styles.replies}>
-        {detail.replies
+        {optimisticReplies
           .filter(
             (r) => !r.is_deleted || isWithinDeleteDisplayWindow(r.updated_at),
           )

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
+import { GlobalFetchIndicator } from "@/components/shared/GlobalFetchIndicator/GlobalFetchIndicator";
 import { OfflineBanner } from "@/components/shared/OfflineBanner/OfflineBanner";
 import { FontSizeProvider } from "@/components/shared/providers/FontSizeProvider";
 import { LocaleInitializer } from "@/components/shared/providers/LocaleInitializer";
@@ -43,6 +44,7 @@ export default async function LocaleLayout({
               単一 Context 参照に変換し、本番での getUserInfo 大量リクエスト問題を解消するため）。
             */}
             <AuthProvider>
+              <GlobalFetchIndicator />
               <OfflineBanner />
               <main
                 style={{ background: "var(--bg-base)", minHeight: "100vh" }}

--- a/frontend/src/components/shared/GlobalFetchIndicator/GlobalFetchIndicator.module.css
+++ b/frontend/src/components/shared/GlobalFetchIndicator/GlobalFetchIndicator.module.css
@@ -1,0 +1,30 @@
+.container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  z-index: var(--z-global-fetch-indicator);
+  pointer-events: none;
+  overflow: hidden;
+  background: transparent;
+}
+
+.bar {
+  position: absolute;
+  top: 0;
+  width: 40%;
+  height: 100%;
+  background: var(--accent-color);
+  opacity: 0.7;
+  animation: slide 1.4s ease-in-out infinite;
+}
+
+@keyframes slide {
+  0% {
+    left: -40%;
+  }
+  100% {
+    left: 100%;
+  }
+}

--- a/frontend/src/components/shared/GlobalFetchIndicator/GlobalFetchIndicator.tsx
+++ b/frontend/src/components/shared/GlobalFetchIndicator/GlobalFetchIndicator.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useIsFetching } from "@tanstack/react-query";
+import styles from "./GlobalFetchIndicator.module.css";
+
+export function GlobalFetchIndicator() {
+  const fetchingCount = useIsFetching();
+  if (fetchingCount === 0) return null;
+
+  return (
+    <div className={styles.container} aria-hidden="true">
+      <div className={styles.bar} />
+    </div>
+  );
+}

--- a/frontend/src/components/shared/providers/QueryProvider.tsx
+++ b/frontend/src/components/shared/providers/QueryProvider.tsx
@@ -3,6 +3,7 @@
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import dynamic from "next/dynamic";
 import type { ReactNode } from "react";
 import { getQueryClient } from "@/lib/query/query-client";
 
@@ -19,6 +20,28 @@ function getPersister() {
   return browserPersister;
 }
 
+// Devtools は本番バンドルから完全に消したいので next/dynamic + ssr:false で lazy import。
+// process.env.NODE_ENV は Next のビルド時に静的置換されるため dead-code-elimination が効く。
+const ReactQueryDevtools =
+  process.env.NODE_ENV !== "production"
+    ? dynamic(
+        () =>
+          import("@tanstack/react-query-devtools").then(
+            (mod) => mod.ReactQueryDevtools,
+          ),
+        { ssr: false },
+      )
+    : null;
+
+// localStorage 永続化を併用しているため、Devtools の "Remove from cache" 操作は
+// localStorage 側を直接書き換えない。乖離が気になる場合は手動で localStorage をクリアする。
+function DevtoolsIfEnabled() {
+  if (!ReactQueryDevtools) return null;
+  return (
+    <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
+  );
+}
+
 export function QueryProvider({ children }: { children: ReactNode }) {
   const queryClient = getQueryClient();
   const persister = getPersister();
@@ -33,16 +56,24 @@ export function QueryProvider({ children }: { children: ReactNode }) {
           maxAge: 12 * 60 * 60 * 1000,
           dehydrateOptions: {
             shouldDehydrateQuery: (query) =>
-              query.state.status === "success" && Boolean(query.state.data),
+              query.state.status === "success" &&
+              Boolean(query.state.data) &&
+              // social-search は検索条件 × InfiniteData の page 蓄積で localStorage (5MB前後) を
+              // 圧迫しうる。検索結果は揮発で十分なので persist 対象から除外する
+              query.queryKey[0] !== "social-search",
           },
         }}
       >
         {children}
+        <DevtoolsIfEnabled />
       </PersistQueryClientProvider>
     );
   }
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <DevtoolsIfEnabled />
+    </QueryClientProvider>
   );
 }

--- a/frontend/src/lib/hooks/useNotifications.ts
+++ b/frontend/src/lib/hooks/useNotifications.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { type InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
 import { getNotifications } from "@/lib/api/client";
 
 export type NotificationTab = "all" | "reply" | "favorite";
@@ -53,7 +53,7 @@ export function useNotifications(
   const query = useInfiniteQuery<
     NotificationsPage,
     Error,
-    InfiniteData<NotificationsPage>,
+    NotificationItemData[],
     ReturnType<typeof notificationsQueryKey>,
     number
   >({
@@ -81,12 +81,11 @@ export function useNotifications(
       };
     },
     getNextPageParam: (lastPage) => lastPage.next_offset ?? undefined,
+    // structural sharing により同一データなら同一参照が返るので、useMemo より再レンダ抑制効果が高い
+    select: (data) => data.pages.flatMap((p) => p.items),
   });
 
-  const notifications = useMemo(
-    () => query.data?.pages.flatMap((p) => p.items) ?? [],
-    [query.data],
-  );
+  const notifications = query.data ?? [];
 
   const loadMore = useCallback(() => {
     if (!query.hasNextPage || query.isFetchingNextPage) return;

--- a/frontend/src/lib/hooks/useSocialFeed.ts
+++ b/frontend/src/lib/hooks/useSocialFeed.ts
@@ -5,7 +5,7 @@ import {
   useInfiniteQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import type { SocialFeedPostData } from "@/components/features/social/SocialPostCard/SocialPostCard";
 import { type GetSocialFeedParams, getSocialFeed } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
@@ -68,7 +68,7 @@ export function useSocialFeed(tab: SocialTab): UseSocialFeedResult {
   const query = useInfiniteQuery<
     SocialFeedPage,
     Error,
-    InfiniteData<SocialFeedPage>,
+    SocialFeedPostData[],
     ReturnType<typeof socialFeedQueryKey>,
     number
   >({
@@ -80,6 +80,8 @@ export function useSocialFeed(tab: SocialTab): UseSocialFeedResult {
       return fetchSocialFeedPage(user.id, tab, pageParam);
     },
     getNextPageParam: (lastPage) => lastPage.next_offset ?? undefined,
+    // structural sharing により同一データなら同一参照が返るので、useMemo より再レンダ抑制効果が高い
+    select: (data) => data.pages.flatMap((p) => p.posts),
   });
 
   // 他タブのプリフェッチ（アクティブタブのロード完了後、idle callback で実行）
@@ -117,10 +119,7 @@ export function useSocialFeed(tab: SocialTab): UseSocialFeedResult {
     return () => clearTimeout(timeoutId);
   }, [user?.id, tab, query.isSuccess, queryClient]);
 
-  const posts = useMemo(
-    () => query.data?.pages.flatMap((p) => p.posts) ?? [],
-    [query.data],
-  );
+  const posts = query.data ?? [];
 
   const hasMore = !!query.hasNextPage;
 

--- a/frontend/src/lib/hooks/useSocialSearch.ts
+++ b/frontend/src/lib/hooks/useSocialSearch.ts
@@ -1,8 +1,9 @@
 "use client";
 
 import {
+  type InfiniteData,
   keepPreviousData,
-  useQuery,
+  useInfiniteQuery,
   useQueryClient,
 } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
@@ -21,12 +22,21 @@ interface SearchInput {
   postType?: "post" | "training_record";
 }
 
+interface SocialSearchPage {
+  posts: SocialFeedPostData[];
+  next_offset: number | null;
+}
+
 interface UseSocialSearchResult {
   results: SocialFeedPostData[];
   /** 初回ロード中（前回結果が無い状態でフェッチ中）。大きな Loader 表示用 */
   isLoading: boolean;
   /** バックグラウンドフェッチ中（前回結果あり、新クエリ実行中）。subtle インジケータ用 */
   isFetching: boolean;
+  /** 追加 page 取得中 */
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  loadMore: () => void;
   search: (
     query: string,
     dojoName?: string,
@@ -58,6 +68,31 @@ export const socialSearchQueryKey = (
   input: SearchInput | null,
 ) => ["social-search", userId, input] as const;
 
+async function fetchSocialSearchPage(
+  userId: string,
+  input: SearchInput,
+  offset: number,
+): Promise<SocialSearchPage> {
+  const params: SearchSocialPostsParams = {
+    userId,
+    query: input.query.trim() || undefined,
+    dojoName: input.dojoName || undefined,
+    rank: input.rank || undefined,
+    hashtag: input.hashtag || undefined,
+    postType: input.postType || undefined,
+    limit: SOCIAL_SEARCH_FETCH_LIMIT,
+    offset,
+  };
+  const result = await searchSocialPosts(params);
+  const posts =
+    result.success && result.data ? (result.data as SocialFeedPostData[]) : [];
+  return {
+    posts,
+    next_offset:
+      posts.length >= SOCIAL_SEARCH_FETCH_LIMIT ? offset + posts.length : null,
+  };
+}
+
 export function useSocialSearch(
   userId: string | undefined,
 ): UseSocialSearchResult {
@@ -68,28 +103,27 @@ export function useSocialSearch(
   const enabled =
     !!userId && !!debouncedInput && hasMeaningfulParams(debouncedInput);
 
-  const query = useQuery<SocialFeedPostData[], Error>({
+  const query = useInfiniteQuery<
+    SocialSearchPage,
+    Error,
+    SocialFeedPostData[],
+    ReturnType<typeof socialSearchQueryKey>,
+    number
+  >({
     queryKey: socialSearchQueryKey(userId, debouncedInput),
     enabled,
-    queryFn: async () => {
-      if (!userId || !debouncedInput) return [];
-      const params: SearchSocialPostsParams = {
-        userId,
-        query: debouncedInput.query.trim() || undefined,
-        dojoName: debouncedInput.dojoName || undefined,
-        rank: debouncedInput.rank || undefined,
-        hashtag: debouncedInput.hashtag || undefined,
-        postType: debouncedInput.postType || undefined,
-        limit: SOCIAL_SEARCH_FETCH_LIMIT,
-      };
-      const result = await searchSocialPosts(params);
-      return result.success && result.data
-        ? (result.data as SocialFeedPostData[])
-        : [];
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      if (!userId || !debouncedInput) {
+        return { posts: [], next_offset: null };
+      }
+      return fetchSocialSearchPage(userId, debouncedInput, pageParam);
     },
+    getNextPageParam: (lastPage) => lastPage.next_offset ?? undefined,
     // 検索条件が変わっても前回の結果リストを保持し、入力中に大きな Loader が
     // 出て画面が空になる UX 悪化を防ぐ
     placeholderData: keepPreviousData,
+    select: (data) => data.pages.flatMap((p) => p.posts),
   });
 
   const search = useCallback(
@@ -110,16 +144,31 @@ export function useSocialSearch(
     [],
   );
 
+  const loadMore = useCallback(() => {
+    if (!query.hasNextPage || query.isFetchingNextPage) return;
+    void query.fetchNextPage();
+  }, [query]);
+
   const updateResult = useCallback(
     (
       postId: string,
       updater: (post: SocialFeedPostData) => SocialFeedPostData,
     ) => {
-      // 全ての social-search キャッシュ（複数の検索条件）の該当 postId を差し替え
-      queryClient.setQueriesData<SocialFeedPostData[]>(
+      // 全ての social-search キャッシュ（複数の検索条件 × InfiniteData）の該当 postId を差し替え
+      queryClient.setQueriesData<InfiniteData<SocialSearchPage>>(
         { queryKey: ["social-search", userId] },
         (old) =>
-          old ? old.map((p) => (p.id === postId ? updater(p) : p)) : old,
+          old
+            ? {
+                ...old,
+                pages: old.pages.map((page) => ({
+                  ...page,
+                  posts: page.posts.map((p) =>
+                    p.id === postId ? updater(p) : p,
+                  ),
+                })),
+              }
+            : old,
       );
     },
     [userId, queryClient],
@@ -129,6 +178,9 @@ export function useSocialSearch(
     results: enabled ? (query.data ?? []) : [],
     isLoading: enabled && query.isLoading,
     isFetching: enabled && query.isFetching && !query.isLoading,
+    isLoadingMore: query.isFetchingNextPage,
+    hasMore: !!query.hasNextPage,
+    loadMore,
     search,
     updateResult,
   };

--- a/frontend/src/styles/variables.css
+++ b/frontend/src/styles/variables.css
@@ -87,6 +87,7 @@
   --z-fab: 10; /* FloatingActionButton, ScrollIndicator */
   --z-tab: 10; /* TabNavigation（FABと同レイヤー） */
   --z-header: 20; /* DefaultHeader, LP Header */
+  --z-global-fetch-indicator: 25; /* GlobalFetchIndicator（header と header-dropdown の間） */
   --z-header-dropdown: 30; /* ヘッダー内ドロップダウン・ツールチップ */
   --z-drawer: 30; /* NavigationDrawer オーバーレイ, LandingMenuDrawer */
   --z-drawer-panel: 31; /* NavigationDrawer パネル本体（オーバーレイより前面） */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@storybook/nextjs-vite':
         specifier: ^9.1.14
         version: 9.1.20(@babel/core@7.28.4)(next@16.2.2)(react-dom@19.2.3)(react@19.2.3)(storybook@9.1.20)(typescript@5.9.2)(vite@7.1.5)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.99.2
+        version: 5.99.2(@tanstack/react-query@5.99.2)(react@19.2.3)
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.8.0
@@ -3749,7 +3752,10 @@ packages:
 
   /@tanstack/query-core@5.99.2:
     resolution: {integrity: sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==}
-    dev: false
+
+  /@tanstack/query-devtools@5.99.2:
+    resolution: {integrity: sha512-TEF1d+RYO9l8oeCwgzmOHIgKwAzXQmw2s/ny2bW8qeg2OMkkLjALfVEivgCMR3OL/jVdMmeTPX56WrV+uvYJFg==}
+    dev: true
 
   /@tanstack/query-persist-client-core@5.99.2:
     resolution: {integrity: sha512-YYuLGBDGCsUbfN2LuYrfkRCpg1vOUZnK2bn4j7zAZv+m1B4CnLAv58Z3A43d5Cruxvld5udYFeYXw9F6g/pZcQ==}
@@ -3763,6 +3769,17 @@ packages:
       '@tanstack/query-core': 5.99.2
       '@tanstack/query-persist-client-core': 5.99.2
     dev: false
+
+  /@tanstack/react-query-devtools@5.99.2(@tanstack/react-query@5.99.2)(react@19.2.3):
+    resolution: {integrity: sha512-8txkK9A9XBNTB8RoxVgfp6W3qwBr25tNP10L4yu3KuyhAdEvccECfIRzesSwMVk/wpVVioAr+hbMtUkMMF+WVw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.99.2
+      react: ^18 || ^19
+    dependencies:
+      '@tanstack/query-devtools': 5.99.2
+      '@tanstack/react-query': 5.99.2(react@19.2.3)
+      react: 19.2.3
+    dev: true
 
   /@tanstack/react-query-persist-client@5.99.2(@tanstack/react-query@5.99.2)(react@19.2.3):
     resolution: {integrity: sha512-7+y5+kpaR26X2gdaEv0yQSFLZjqXz4Kn7wqzuYDQrb203b9MlYS3baML1M9hJTiLgi4QGGF2eJDdW8lHAazUow==}
@@ -3782,7 +3799,6 @@ packages:
     dependencies:
       '@tanstack/query-core': 5.99.2
       react: 19.2.3
-    dev: false
 
   /@testing-library/dom@10.4.1:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}


### PR DESCRIPTION
## Summary

TanStack Query (React Query) v5 の活用度を上げる改善を 1 つの PR にまとめました。Zenn 記事「[React Query Patterns](https://zenn.dev/correlate_dev/articles/react-query-patterns)」での推奨パターンと現状実装を突き合わせ、低リスクかつ体感効果の大きい改善を実施しています。

### 改善内容

- **検索画面の無限スクロール化** (`useSocialSearch.ts` / `SocialSearchResults.tsx`)
  - これまで `useQuery` + `limit: 20` で 21件目以降が見えなかった問題を解消
  - `useInfiniteQuery` + IntersectionObserver (rootMargin 200px) で末端到達時に自動追加読み込み
  - バックエンド `/api/social/search` は既に `offset` 対応済みのため改修不要
- **React 19 `useOptimistic` を返信編集に試験導入** (`SocialPostDetail.tsx`)
  - `startTransition` 内で `addOptimisticReply` を呼ぶことで、保存押下時に即時 UI 反映
  - 失敗時は React 19 の仕様で transition 終了時に自動ロールバック
  - 単一画面・単一 cache で完結する操作のみ採用（cross-cache が必要ないいね・削除等は既存の `setQueryData` を維持）
- **`@tanstack/react-query-devtools` 導入** (`QueryProvider.tsx` / `package.json`)
  - `next/dynamic` + `process.env.NODE_ENV !== "production"` 条件で本番バンドルから DCE
  - 既存 react-query と同 v5.99.2 にバージョン固定
- **`useMemo` → `select` 置換** (`useSocialFeed.ts` / `useNotifications.ts`)
  - structural sharing で同一データなら同一参照が返り、Component 再レンダ抑制
- **`GlobalFetchIndicator` 新設** (`components/shared/GlobalFetchIndicator/`)
  - 上端 2px の薄い `var(--accent-color)` バーを `useIsFetching()` で監視
  - z-index 変数 `--z-global-fetch-indicator: 25` を `variables.css` に追加（header 20 と header-dropdown 30 の中間）
- **localStorage persist の検索結果除外** (`QueryProvider.tsx`)
  - `social-search` キーは検索条件 × InfiniteData の page 蓄積で容量圧迫しうるため `shouldDehydrateQuery` で除外
- **使い分け基準ドキュメント新設** (`frontend/docs/tanstack-query-patterns.md`)
  - `useQuery` / `useInfiniteQuery` / `setQueryData` / `useOptimistic` の判断フローと参考実装一覧

## Test plan

### 自動チェック
- [x] `pnpm exec tsc --noEmit` (frontend, 0 errors)
- [x] `pnpm check:fix` (Biome、新規エラーなし。9 件の warning は既存)
- [x] `pnpm test:ci` (frontend, 36 files / 284 tests pass)
- [x] `pnpm test` (backend, 23 files / 220 tests pass)

### ローカル動作確認 (http://localhost:3000)
- [x] 画面右下に Devtools フローティングボタンが表示される（dev のみ、本番ビルドで非表示）
- [x] `/ja/social/posts/search` で 21件以上ヒットするキーワード入力 → 末端スクロールで自動追加読み込み
- [x] 検索条件変更時に前結果が一時保持される (`placeholderData: keepPreviousData`)
- [x] `/ja/social/posts` のタブ切替（all/training/favorites）で挙動劣化なし
- [x] タブ切替・検索時に画面最上端に薄い橙バーが流れる
- [x] `/ja/social/posts/[post_id]` で返信編集 → 即時反映、Network Offline 化で自動ロールバック
- [x] SP 375px / 450px 幅で表示崩れなし（GlobalFetchIndicator の重なり順含む）