### PR TITLE
fix: プロフィール画像 input の accept から HEIC を除外

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/profile/edit/ProfileEdit.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/profile/edit/ProfileEdit.tsx
@@ -400,7 +400,7 @@ export const ProfileEdit: FC<ProfileEditProps> = ({
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/*"
+                accept="image/jpeg,image/jpg,image/png,image/webp"
                 onChange={onImageSelect}
                 className={styles.fileInput}
               />


### PR DESCRIPTION
## Summary

Apple App Review (Build 25) でカメラ起動時のクラッシュリジェクト (Guideline 2.1(a)) を受け、その**二次原因の予防**としてプロフィール画像編集の \`accept\` 属性を明示形式に絞ります。

主因の Info.plist 修正は aikinote-native-app 側の PR で対応中（Tomoya-Sonok/aikinote-native-app#3）。

## 背景

\`frontend/src/app/[locale]/(authenticated)/profile/edit/ProfileEdit.tsx\` の \`<input type=\"file\" accept=\"image/*\">\` は、iPhone 標準カメラで撮影された **HEIC** を選択可能にしてしまう。一方で本アプリの画像処理パイプライン (\`compressImage.ts\` / \`cropImage.ts\`) は Canvas API ベースで HEIC を decode できない。HEIC を渡すと

- Canvas \`drawImage\` でエラー or 空画像
- 大画像で memory pressure → WebView クラッシュ

の経路を抱えていた。

ページ作成側 (\`PageCreate.tsx\` L318) は既に \`image/jpeg,image/jpg,image/png,image/webp,video/...\` と列挙していたため、プロフィール側も**画像部分のみ揃える**形で統一する。

## Diff

```diff
-                accept=\"image/*\"
+                accept=\"image/jpeg,image/jpg,image/png,image/webp\"
```

## Test plan

- [x] iOS の写真ピッカーで HEIC が選択肢に現れない（撮影直後は HEIC のままピッカーに残らない）こと
- [x] JPEG/PNG/WebP は引き続き選択・アップロードできること
- [x] Android / PC ブラウザでも JPEG/PNG/WebP が選べ、トリミング → アップロードまで動くこと

## 関連

- aikinote-native-app PR #3: Info.plist に \`NSCameraUsageDescription\` 等を追加（こちらが主因の修正）
- 将来課題: \`heic2any\` 等を導入して HEIC → JPEG 変換 (今回スコープ外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)