### PR TITLE
feat(personal): Native ブリッジアダプタ層と統計・カレンダーのオフラインガード (PR3/6)

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/calendar/PersonalCalendar.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/calendar/PersonalCalendar.tsx
@@ -11,6 +11,7 @@ import { createPortal } from "react-dom";
 import { CalendarGrid } from "@/components/features/personal/CalendarGrid/CalendarGrid";
 import { Button } from "@/components/shared/Button/Button";
 import { Loader } from "@/components/shared/Loader";
+import { OfflineGuard } from "@/components/shared/OfflineGuard";
 import { useToast } from "@/contexts/ToastContext";
 import {
   getTrainingDatesMonth,
@@ -18,6 +19,8 @@ import {
   upsertTrainingDateAttendance,
 } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
+import { useIsNativeApp } from "@/lib/hooks/useIsNativeApp";
+import { useOnlineStatus } from "@/lib/hooks/useOnlineStatus";
 import { useUmamiTrack } from "@/lib/hooks/useUmamiTrack";
 import { useRouter } from "@/lib/i18n/routing";
 import { getNetworkAwareErrorMessage } from "@/lib/utils/offlineError";
@@ -141,6 +144,8 @@ export function PersonalCalendar() {
   const tRef = useRef(t);
   const { user, loading: authLoading } = useAuth();
   const { track } = useUmamiTrack();
+  const isOnline = useOnlineStatus();
+  const isNative = useIsNativeApp();
   const [currentMonth, setCurrentMonth] = useState(() => {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), 1);
@@ -442,6 +447,13 @@ export function PersonalCalendar() {
   const actionTitle = selectedDateKey
     ? t("personalCalendar.actionTitle", { date: selectedDateKey })
     : "";
+
+  // ネイティブアプリ + オフライン時は専用ガード画面を表示。
+  // カレンダー操作 (出欠登録 / 試験目標 / リマインダー) はサーバー API 必須で
+  // ローカル算出に対応していないため、オフラインでは利用不可。
+  if (isNative && !isOnline) {
+    return <OfflineGuard />;
+  }
 
   return (
     <div className={styles.container}>

--- a/frontend/src/app/[locale]/(authenticated)/personal/stats/PersonalStats.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/stats/PersonalStats.tsx
@@ -4,10 +4,13 @@ import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { DateRangeInput } from "@/components/shared/DateRangeInput/DateRangeInput";
+import { OfflineGuard } from "@/components/shared/OfflineGuard";
 import { PremiumUpgradeModal } from "@/components/shared/PremiumUpgradeModal/PremiumUpgradeModal";
 import { Skeleton } from "@/components/shared/Skeleton";
 import { getCategories } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
+import { useIsNativeApp } from "@/lib/hooks/useIsNativeApp";
+import { useOnlineStatus } from "@/lib/hooks/useOnlineStatus";
 import { useSubscription } from "@/lib/hooks/useSubscription";
 import { useTrainingStats } from "@/lib/hooks/useTrainingStats";
 import type { UserCategory } from "@/types/category";
@@ -84,6 +87,8 @@ function computeDuration(firstDate: string | null): {
 export function PersonalStats() {
   const t = useTranslations("premiumModalStats");
   const { isPremium, loading: subLoading } = useSubscription();
+  const isOnline = useOnlineStatus();
+  const isNative = useIsNativeApp();
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [showPreviewLock, setShowPreviewLock] = useState(false);
 
@@ -104,6 +109,14 @@ export function PersonalStats() {
     setShowUpgradeModal(false);
     setShowPreviewLock(true);
   }, []);
+
+  // ネイティブアプリ + オフライン時は専用ガード画面を表示。
+  // 統計はサーバー集計が必須でローカル算出に対応していないため、
+  // 「ひとりで」のページ閲覧と違ってオフラインでは利用不可。
+  // 注意: すべての hooks 呼び出しの後に早期 return すること
+  if (isNative && !isOnline) {
+    return <OfflineGuard />;
+  }
 
   if (isPremium) {
     return <PersonalStatsContent />;

--- a/frontend/src/components/features/personal/AttachmentUpload/AttachmentUpload.tsx
+++ b/frontend/src/components/features/personal/AttachmentUpload/AttachmentUpload.tsx
@@ -5,10 +5,17 @@ import { useTranslations } from "next-intl";
 import type { FC } from "react";
 import { useCallback, useRef, useState } from "react";
 import { ATTACHMENT_MAX_COUNT } from "@/lib/aws-s3";
+import { useIsNativeApp } from "@/lib/hooks/useIsNativeApp";
 import { compressImage } from "@/lib/utils/compressImage";
 import type { AttachmentData } from "../AttachmentCard/AttachmentCard";
 import { AttachmentCard } from "../AttachmentCard/AttachmentCard";
 import styles from "./AttachmentUpload.module.css";
+
+// Web ブラウザでは画像 + 動画を受け付ける。ネイティブアプリ (Expo WebView) では
+// 動画のオフライン対応がストレージ負担の都合で未実装のため、画像のみに絞る。
+const ACCEPT_WEB =
+  "image/jpeg,image/jpg,image/png,image/webp,video/mp4,video/quicktime,video/webm";
+const ACCEPT_NATIVE = "image/jpeg,image/jpg,image/png,image/webp";
 
 interface AttachmentUploadProps {
   attachments: AttachmentData[];
@@ -44,6 +51,7 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
   uploadType = "page-attachment",
 }) => {
   const t = useTranslations();
+  const isNative = useIsNativeApp();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const xhrRef = useRef<XMLHttpRequest | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -315,7 +323,7 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
         ref={fileInputRef}
         type="file"
         multiple
-        accept="image/jpeg,image/jpg,image/png,image/webp,video/mp4,video/quicktime,video/webm"
+        accept={isNative ? ACCEPT_NATIVE : ACCEPT_WEB}
         onChange={handleFileSelect}
         disabled={disabled || isUploading || isMaxReached}
         className={styles.hiddenInput}
@@ -328,9 +336,16 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
           className={styles.fileButton}
           onClick={handleUploadClick}
           disabled={disabled || isUploading || isMaxReached}
+          title={
+            isNative
+              ? t("pageModal.attachments.nativeVideoUnavailable")
+              : undefined
+          }
         >
           <ImageIcon size={16} />
-          <VideoCamera size={16} />
+          {/* ネイティブアプリでは動画アップロード未対応 (PR スコープ外) のため
+              VideoCamera アイコンは非表示にして UI を画像のみに見せる */}
+          {!isNative && <VideoCamera size={16} />}
           {t("pageModal.attachments.addFile")}
         </button>
       </div>

--- a/frontend/src/components/shared/OfflineGuard/OfflineGuard.module.css
+++ b/frontend/src/components/shared/OfflineGuard/OfflineGuard.module.css
@@ -1,0 +1,42 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  min-height: 60vh;
+  padding: 32px 24px;
+  text-align: center;
+}
+
+.message {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-light);
+  line-height: 1.6;
+  max-width: 320px;
+}
+
+.retryButton {
+  margin-top: 8px;
+  padding: 10px 24px;
+  background: var(--white);
+  color: var(--black);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.retryButton:hover {
+  background: var(--background-light);
+  border-color: var(--primary-color);
+}
+
+.retryButton:active {
+  background: var(--background-light);
+}

--- a/frontend/src/components/shared/OfflineGuard/OfflineGuard.test.tsx
+++ b/frontend/src/components/shared/OfflineGuard/OfflineGuard.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+import { OfflineGuard } from "./OfflineGuard";
+
+const messages = {
+  offlineGuard: {
+    message: "ネットワークが接続されている状態でしかご利用いただけません",
+    retry: "再試行",
+  },
+};
+
+function renderWithIntl(ui: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="ja" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("OfflineGuard", () => {
+  it("メッセージと再試行ボタンが表示される", () => {
+    // Arrange & Act
+    renderWithIntl(<OfflineGuard />);
+
+    // Assert
+    expect(
+      screen.getByText(
+        "ネットワークが接続されている状態でしかご利用いただけません",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "再試行" })).toBeTruthy();
+  });
+
+  it("onRetry が指定されているとボタン押下で呼ばれる", () => {
+    // Arrange
+    const onRetry = vi.fn();
+    renderWithIntl(<OfflineGuard onRetry={onRetry} />);
+
+    // Act
+    screen.getByRole("button", { name: "再試行" }).click();
+
+    // Assert
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/shared/OfflineGuard/OfflineGuard.tsx
+++ b/frontend/src/components/shared/OfflineGuard/OfflineGuard.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { WifiSlashIcon } from "@phosphor-icons/react";
+import { useTranslations } from "next-intl";
+import { useCallback } from "react";
+import styles from "./OfflineGuard.module.css";
+
+interface OfflineGuardProps {
+  /** 再試行ボタン押下時の処理。未指定なら window.location.reload() */
+  onRetry?: () => void;
+}
+
+/**
+ * ネットワーク未接続時にコンテンツの代わりに表示するガード画面。
+ *
+ * 統計・カレンダーなどの「サーバー必須」機能でオフライン状態のときに使う。
+ * 「ひとりで」のページ作成・編集・閲覧は SQLite ベースのオフライン対応が
+ * 入るため、こちらの guard は使わない (Native かつオフラインでも動作する)。
+ */
+export function OfflineGuard({ onRetry }: OfflineGuardProps) {
+  const t = useTranslations("offlineGuard");
+
+  const handleRetry = useCallback(() => {
+    if (onRetry) {
+      onRetry();
+      return;
+    }
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  }, [onRetry]);
+
+  return (
+    <output className={styles.container} aria-live="polite">
+      <WifiSlashIcon
+        size={64}
+        weight="light"
+        color="var(--text-light)"
+        aria-hidden="true"
+      />
+      <p className={styles.message}>{t("message")}</p>
+      <button
+        type="button"
+        className={styles.retryButton}
+        onClick={handleRetry}
+      >
+        {t("retry")}
+      </button>
+    </output>
+  );
+}

--- a/frontend/src/components/shared/OfflineGuard/index.ts
+++ b/frontend/src/components/shared/OfflineGuard/index.ts
@@ -1,0 +1,1 @@
+export { OfflineGuard } from "./OfflineGuard";

--- a/frontend/src/lib/api/native-bridge.test.ts
+++ b/frontend/src/lib/api/native-bridge.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetBridgeForTest,
+  BridgeCallError,
+  callPersonalBridge,
+  isNativeApp,
+} from "./native-bridge";
+
+interface BridgeTestWindow {
+  __AIKINOTE_NATIVE_APP__?: boolean;
+  __onNativeMessage?: (msg: unknown) => void;
+  ReactNativeWebView?: { postMessage: (msg: string) => void };
+}
+
+const getTestWindow = (): BridgeTestWindow =>
+  window as unknown as BridgeTestWindow;
+
+describe("isNativeApp", () => {
+  afterEach(() => {
+    delete getTestWindow().__AIKINOTE_NATIVE_APP__;
+    _resetBridgeForTest();
+  });
+
+  it("__AIKINOTE_NATIVE_APP__ が true なら true を返す", () => {
+    // Arrange
+    getTestWindow().__AIKINOTE_NATIVE_APP__ = true;
+
+    // Act & Assert
+    expect(isNativeApp()).toBe(true);
+  });
+
+  it("__AIKINOTE_NATIVE_APP__ が未設定なら false", () => {
+    // Arrange
+    delete getTestWindow().__AIKINOTE_NATIVE_APP__;
+
+    // Act & Assert
+    expect(isNativeApp()).toBe(false);
+  });
+});
+
+describe("callPersonalBridge", () => {
+  beforeEach(() => {
+    _resetBridgeForTest();
+    getTestWindow().__AIKINOTE_NATIVE_APP__ = true;
+    delete getTestWindow().__onNativeMessage;
+  });
+
+  afterEach(() => {
+    delete getTestWindow().__AIKINOTE_NATIVE_APP__;
+    delete getTestWindow().__onNativeMessage;
+    delete getTestWindow().ReactNativeWebView;
+    _resetBridgeForTest();
+  });
+
+  it("Native 環境外では NOT_IN_NATIVE_APP エラーで reject", async () => {
+    // Arrange
+    delete getTestWindow().__AIKINOTE_NATIVE_APP__;
+
+    // Act & Assert
+    await expect(callPersonalBridge("PERSONAL_PAGES_LIST")).rejects.toThrow(
+      BridgeCallError,
+    );
+  });
+
+  it("ReactNativeWebView が無いと NO_BRIDGE で reject", async () => {
+    // Arrange
+    delete getTestWindow().ReactNativeWebView;
+
+    // Act
+    const promise = callPersonalBridge("PERSONAL_PAGES_LIST");
+
+    // Assert
+    await expect(promise).rejects.toMatchObject({ code: "NO_BRIDGE" });
+  });
+
+  it("Native 側が ok:true で返したら data を resolve", async () => {
+    // Arrange
+    const postMessage = vi.fn((message: string) => {
+      const parsed = JSON.parse(message) as { requestId: string };
+      // 同期的に __onNativeMessage を呼んで成功レスポンスを返す
+      getTestWindow().__onNativeMessage?.({
+        type: "PERSONAL_PAGES_LIST_RESULT",
+        payload: {
+          requestId: parsed.requestId,
+          ok: true,
+          data: [{ local_id: "page-1", title: "テスト" }],
+        },
+      });
+    });
+    getTestWindow().ReactNativeWebView = { postMessage };
+
+    // Act
+    const result = await callPersonalBridge<Array<{ local_id: string }>>(
+      "PERSONAL_PAGES_LIST",
+      { userId: "u1" },
+    );
+
+    // Assert
+    expect(result).toEqual([{ local_id: "page-1", title: "テスト" }]);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("Native 側が ok:false で返したら BridgeCallError で reject", async () => {
+    // Arrange
+    getTestWindow().ReactNativeWebView = {
+      postMessage: (message: string) => {
+        const parsed = JSON.parse(message) as { requestId: string };
+        getTestWindow().__onNativeMessage?.({
+          type: "PERSONAL_PAGES_GET_RESULT",
+          payload: {
+            requestId: parsed.requestId,
+            ok: false,
+            error: { code: "NOT_FOUND", message: "page missing" },
+          },
+        });
+      },
+    };
+
+    // Act
+    const promise = callPersonalBridge("PERSONAL_PAGES_GET", {
+      pageId: "x",
+    });
+
+    // Assert
+    await expect(promise).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "page missing",
+    });
+  });
+
+  it("既存の __onNativeMessage は PERSONAL 以外のメッセージで温存される", async () => {
+    // Arrange
+    const existingHandler = vi.fn();
+    getTestWindow().__onNativeMessage = existingHandler;
+    getTestWindow().ReactNativeWebView = {
+      postMessage: (message: string) => {
+        const parsed = JSON.parse(message) as { requestId: string };
+        getTestWindow().__onNativeMessage?.({
+          type: "PERSONAL_PAGES_LIST_RESULT",
+          payload: { requestId: parsed.requestId, ok: true, data: [] },
+        });
+      },
+    };
+
+    // Act
+    await callPersonalBridge("PERSONAL_PAGES_LIST");
+    // 既存 IAP/OAuth メッセージのシミュレーション
+    getTestWindow().__onNativeMessage?.({
+      type: "IAP_RESULT",
+      payload: { success: true },
+    });
+
+    // Assert
+    expect(existingHandler).toHaveBeenCalledWith({
+      type: "IAP_RESULT",
+      payload: { success: true },
+    });
+  });
+
+  it("タイムアウト後は TIMEOUT エラー", async () => {
+    // Arrange
+    vi.useFakeTimers();
+    getTestWindow().ReactNativeWebView = { postMessage: vi.fn() };
+
+    // Act
+    const promise = callPersonalBridge(
+      "PERSONAL_PAGES_LIST",
+      {},
+      {
+        timeoutMs: 100,
+      },
+    );
+    vi.advanceTimersByTime(101);
+
+    // Assert
+    await expect(promise).rejects.toMatchObject({ code: "TIMEOUT" });
+
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/lib/api/native-bridge.ts
+++ b/frontend/src/lib/api/native-bridge.ts
@@ -1,0 +1,211 @@
+"use client";
+
+// ネイティブアプリ (Expo WebView) との Promise ベースブリッジ。
+//
+// Native 側仕様: aikinote-native-app/docs/webview-bridge-protocol.md
+// Native 側 dispatcher: aikinote-native-app/lib/bridge/personal-handlers.ts
+//
+// 既存の IAP / OAuth で確立済みの window.__onNativeMessage パターンを尊重しつつ、
+// PERSONAL_*_RESULT メッセージだけは requestId ベースの自前 Promise resolver に
+// 流す。__onNativeMessage 自体は Native 側の WebView injection (aikinote-webview.tsx)
+// で定義されるため、本モジュールはその関数を「ラップ」して先頭に判定を入れる
+// (既存 IAP/OAuth resolver は wrapped prev に委譲)。
+//
+// 本 PR (PR3) では:
+//   - call 関数は実装するが、フックからの呼び出し配線は PR6 (初回フルプル完成時) に集約
+//   - 後続 PR が import するだけで使える状態にする
+
+interface BridgeErrorPayload {
+  code: string;
+  message: string;
+}
+
+interface BridgeResponseOk<T> {
+  requestId: string;
+  ok: true;
+  data: T;
+}
+
+interface BridgeResponseErr {
+  requestId: string;
+  ok: false;
+  error?: BridgeErrorPayload;
+}
+
+type BridgeResponse<T> = BridgeResponseOk<T> | BridgeResponseErr;
+
+interface NativeMessage {
+  type?: unknown;
+  payload?: unknown;
+}
+
+type NativeMessageHandler = (msg: NativeMessage) => void;
+
+interface NativeWindow {
+  __AIKINOTE_NATIVE_APP__?: boolean;
+  __onNativeMessage?: NativeMessageHandler;
+  ReactNativeWebView?: { postMessage: (message: string) => void };
+}
+
+declare global {
+  interface Window {
+    __AIKINOTE_NATIVE_APP__?: boolean;
+    ReactNativeWebView?: { postMessage: (message: string) => void };
+  }
+}
+
+export class BridgeCallError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "BridgeCallError";
+    this.code = code;
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+type PendingResolver = (response: BridgeResponse<unknown>) => void;
+const pending = new Map<string, PendingResolver>();
+let handlerInstalled = false;
+
+export function isNativeApp(): boolean {
+  if (typeof window === "undefined") return false;
+  return !!(window as NativeWindow).__AIKINOTE_NATIVE_APP__;
+}
+
+function generateRequestId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `req_${crypto.randomUUID()}`;
+  }
+  return `req_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * window.__onNativeMessage を先頭に「PERSONAL_*_RESULT を pending から resolve」
+ * する処理でラップする。既存 handler (IAP / SUBSCRIPTION / OAUTH 等) は
+ * prev として保持して引き続き呼ぶ。
+ *
+ * idempotent: 何度呼ばれても一度だけインストール。
+ */
+function installResultHandler(): void {
+  if (handlerInstalled || typeof window === "undefined") return;
+  handlerInstalled = true;
+
+  const win = window as NativeWindow;
+  const prev = win.__onNativeMessage;
+
+  win.__onNativeMessage = (msg: NativeMessage) => {
+    if (
+      typeof msg?.type === "string" &&
+      msg.type.startsWith("PERSONAL_") &&
+      msg.type.endsWith("_RESULT")
+    ) {
+      const payload = msg.payload as
+        | {
+            requestId?: string;
+            ok?: boolean;
+            data?: unknown;
+            error?: BridgeErrorPayload;
+          }
+        | undefined;
+      const requestId = payload?.requestId;
+      if (typeof requestId === "string") {
+        const resolver = pending.get(requestId);
+        if (resolver) {
+          pending.delete(requestId);
+          resolver(payload as BridgeResponse<unknown>);
+          return;
+        }
+      }
+    }
+
+    // PERSONAL 以外 (IAP / SUBSCRIPTION_STATUS / OAUTH_RESULT 等) は既存 handler に委譲
+    if (typeof prev === "function") {
+      prev(msg);
+    }
+  };
+}
+
+interface CallBridgeOptions {
+  timeoutMs?: number;
+}
+
+/**
+ * PERSONAL_* メッセージを Native 側へ送り、レスポンスを Promise で待つ。
+ * Native 環境以外で呼ぶと NOT_IN_NATIVE_APP エラー。
+ */
+export async function callPersonalBridge<T = unknown>(
+  type: string,
+  payload: Record<string, unknown> = {},
+  options: CallBridgeOptions = {},
+): Promise<T> {
+  if (!isNativeApp()) {
+    throw new BridgeCallError(
+      "NOT_IN_NATIVE_APP",
+      "callPersonalBridge は Native WebView 環境でのみ利用できます。",
+    );
+  }
+  const win = window as NativeWindow;
+  if (!win.ReactNativeWebView) {
+    throw new BridgeCallError(
+      "NO_BRIDGE",
+      "window.ReactNativeWebView が利用できません。",
+    );
+  }
+
+  installResultHandler();
+
+  const requestId = generateRequestId();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (pending.delete(requestId)) {
+        reject(
+          new BridgeCallError(
+            "TIMEOUT",
+            `Bridge call ${type} timed out after ${timeoutMs}ms`,
+          ),
+        );
+      }
+    }, timeoutMs);
+
+    pending.set(requestId, (response) => {
+      clearTimeout(timer);
+      if (response.ok) {
+        resolve(response.data as T);
+      } else {
+        reject(
+          new BridgeCallError(
+            response.error?.code ?? "UNKNOWN",
+            response.error?.message ?? `Bridge call ${type} failed.`,
+          ),
+        );
+      }
+    });
+
+    try {
+      win.ReactNativeWebView!.postMessage(
+        JSON.stringify({ type, requestId, payload }),
+      );
+    } catch (error) {
+      pending.delete(requestId);
+      clearTimeout(timer);
+      reject(
+        new BridgeCallError(
+          "POST_MESSAGE_FAILED",
+          error instanceof Error ? error.message : String(error),
+        ),
+      );
+    }
+  });
+}
+
+/**
+ * テスト用: pending map と handler 状態をリセット。
+ */
+export function _resetBridgeForTest(): void {
+  pending.clear();
+  handlerInstalled = false;
+}

--- a/frontend/src/lib/api/personal-adapter.ts
+++ b/frontend/src/lib/api/personal-adapter.ts
@@ -1,0 +1,322 @@
+"use client";
+
+// 「ひとりで」(personal pages) 関連 API のアダプタ層。
+//
+// Web ブラウザ環境では従来どおり remote (tRPC 経由 / Supabase) を呼び、
+// ネイティブアプリ (Expo WebView) の中で動いているときは Native SQLite
+// ブリッジ (PERSONAL_*) 経由でローカル DB を読み書きする。
+//
+// 本 PR (PR3) では:
+//   - 関数群は実装するが、各フックからの import 切替は PR6 (初回フルプル+
+//     画像オフライン+同期エンジン完成後) に集約する。先行して呼ぶと
+//     Native 側 PR4/PR5 未着の状態でデータが空に見えるためユーザー体験が
+//     劣化する
+//   - 既存 client.ts は触らず、その関数を default の remote 実装として
+//     利用する
+//
+// 仕様: aikinote-native-app/docs/webview-bridge-protocol.md
+
+import type {
+  CreatePagePayload,
+  CreateTagPayload,
+  GetPagesParams,
+  UpdatePagePayload,
+} from "@/lib/api/client";
+import * as remote from "@/lib/api/client";
+import {
+  BridgeCallError,
+  callPersonalBridge,
+  isNativeApp,
+} from "./native-bridge";
+
+// Native SQLite 行型 (aikinote-native-app/lib/db/schema.ts と対応)
+interface SQLitePageRow {
+  local_id: string;
+  server_id: string | null;
+  user_id: string;
+  title: string;
+  content: string;
+  is_public: 0 | 1;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+interface SQLiteTagRow {
+  local_id: string;
+  server_id: string | null;
+  user_id: string;
+  name: string;
+  category: string;
+  sort_order: number;
+}
+
+interface SQLiteCategoryRow {
+  local_id: string;
+  server_id: string | null;
+  user_id: string;
+  name: string;
+  slug: string;
+  sort_order: number;
+  is_default: 0 | 1;
+}
+
+/**
+ * Bridge が NOT_IMPLEMENTED や TIMEOUT を返したときに remote (tRPC) に
+ * 暫定フォールバックする helper。
+ * 同期エンジン (PR4) と画像オフライン (PR5) が揃うまでは、各種ハンドラの
+ * 一部が NOT_IMPLEMENTED で返るためフォールバックが必要。
+ */
+async function bridgeOrRemote<T>(
+  bridge: () => Promise<T>,
+  remoteFallback: () => Promise<T>,
+): Promise<T> {
+  if (!isNativeApp()) return remoteFallback();
+  try {
+    return await bridge();
+  } catch (error) {
+    if (
+      error instanceof BridgeCallError &&
+      (error.code === "NOT_IMPLEMENTED" ||
+        error.code === "NO_BRIDGE" ||
+        error.code === "NOT_IN_NATIVE_APP")
+    ) {
+      return remoteFallback();
+    }
+    throw error;
+  }
+}
+
+// ============================== Pages ==============================
+
+type RemoteResult<F extends (...args: never[]) => unknown> = Awaited<
+  ReturnType<F>
+>;
+
+export async function getPages(params: GetPagesParams) {
+  return bridgeOrRemote(
+    async () => {
+      const rows = await callPersonalBridge<SQLitePageRow[]>(
+        "PERSONAL_PAGES_LIST",
+        {
+          userId: params.userId,
+          limit: params.limit,
+          offset: params.offset,
+          query: params.query,
+          startDate: params.startDate,
+          endDate: params.endDate,
+          sortOrder: params.sortOrder,
+        },
+      );
+      // remote の戻り値型に合わせるためキャストする。SQLite 側ハンドラは
+      // tags/attachments を未同梱なので、PR6 で正規化を完成させる時に
+      // ハンドラ拡張 + 厳密化する予定。
+      return normalizePagesListResponse(
+        rows,
+        params,
+      ) as unknown as RemoteResult<typeof remote.getPages>;
+    },
+    () => remote.getPages(params),
+  );
+}
+
+export async function getPage(pageId: string, userId: string) {
+  return bridgeOrRemote(
+    async () => {
+      const row = await callPersonalBridge<
+        SQLitePageRow & { tags: SQLiteTagRow[] }
+      >("PERSONAL_PAGES_GET", { pageId, userId });
+      return {
+        success: true,
+        data: {
+          page: normalizePageRow(row),
+          tags: row.tags.map((tag) => ({ id: tag.local_id, name: tag.name })),
+          attachments: [],
+        },
+      } as unknown as RemoteResult<typeof remote.getPage>;
+    },
+    () => remote.getPage(pageId, userId),
+  );
+}
+
+export async function createPage(pageData: CreatePagePayload) {
+  return bridgeOrRemote(
+    async () => {
+      const result = await callPersonalBridge<{
+        localId: string;
+        serverId: string | null;
+      }>("PERSONAL_PAGES_CREATE", {
+        userId: pageData.user_id,
+        title: pageData.title,
+        content: pageData.content,
+        isPublic: pageData.is_public,
+        createdAt: pageData.created_at,
+      });
+      return {
+        success: true,
+        data: { id: result.localId, server_id: result.serverId },
+      } as unknown as RemoteResult<typeof remote.createPage>;
+    },
+    () => remote.createPage(pageData),
+  );
+}
+
+export async function updatePage(pageData: UpdatePagePayload) {
+  return bridgeOrRemote(
+    async () => {
+      const result = await callPersonalBridge<{ localId: string }>(
+        "PERSONAL_PAGES_UPDATE",
+        {
+          pageId: pageData.id,
+          title: pageData.title,
+          content: pageData.content,
+          isPublic: pageData.is_public,
+        },
+      );
+      return {
+        success: true,
+        data: { id: result.localId },
+      } as unknown as RemoteResult<typeof remote.updatePage>;
+    },
+    () => remote.updatePage(pageData),
+  );
+}
+
+export async function deletePage(pageId: string, userId: string) {
+  return bridgeOrRemote(
+    async () => {
+      await callPersonalBridge<Record<string, never>>("PERSONAL_PAGES_DELETE", {
+        pageId,
+        userId,
+      });
+      return { success: true } as unknown as RemoteResult<
+        typeof remote.deletePage
+      >;
+    },
+    () => remote.deletePage(pageId, userId),
+  );
+}
+
+export async function togglePageVisibility(
+  pageId: string,
+  userId: string,
+  isPublic: boolean,
+) {
+  return bridgeOrRemote(
+    async () => {
+      await callPersonalBridge<{ localId: string; isPublic: boolean }>(
+        "PERSONAL_PAGES_TOGGLE_VISIBILITY",
+        { pageId, userId, isPublic },
+      );
+      return { success: true } as unknown as RemoteResult<
+        typeof remote.togglePageVisibility
+      >;
+    },
+    () => remote.togglePageVisibility(pageId, userId, isPublic),
+  );
+}
+
+// ============================== Tags ==============================
+
+export async function getTags(userId: string) {
+  return bridgeOrRemote(
+    async () => {
+      const rows = await callPersonalBridge<SQLiteTagRow[]>(
+        "PERSONAL_TAGS_LIST",
+        { userId },
+      );
+      return {
+        success: true,
+        data: rows.map((row) => ({
+          id: row.local_id,
+          name: row.name,
+          category: row.category,
+          user_id: row.user_id,
+        })),
+      } as unknown as RemoteResult<typeof remote.getTags>;
+    },
+    () => remote.getTags(userId),
+  );
+}
+
+export async function createTag(tagData: CreateTagPayload) {
+  return bridgeOrRemote(
+    async () => {
+      const row = await callPersonalBridge<SQLiteTagRow>(
+        "PERSONAL_TAGS_CREATE",
+        {
+          userId: tagData.user_id,
+          name: tagData.name,
+          category: tagData.category,
+        },
+      );
+      return {
+        success: true,
+        data: {
+          id: row.local_id,
+          name: row.name,
+          category: row.category,
+          user_id: row.user_id,
+        },
+      } as unknown as RemoteResult<typeof remote.createTag>;
+    },
+    () => remote.createTag(tagData),
+  );
+}
+
+// ============================== Categories ==============================
+
+export async function getCategories(userId: string) {
+  return bridgeOrRemote(
+    async () => {
+      const rows = await callPersonalBridge<SQLiteCategoryRow[]>(
+        "PERSONAL_CATEGORIES_LIST",
+        { userId },
+      );
+      return {
+        success: true,
+        data: rows.map((row) => ({
+          id: row.local_id,
+          name: row.name,
+          slug: row.slug,
+          sort_order: row.sort_order,
+          is_default: row.is_default === 1,
+        })),
+      } as unknown as RemoteResult<typeof remote.getCategories>;
+    },
+    () => remote.getCategories(userId),
+  );
+}
+
+// ============================== Helpers ==============================
+
+function normalizePageRow(row: SQLitePageRow) {
+  return {
+    id: row.local_id,
+    title: row.title,
+    content: row.content,
+    is_public: row.is_public === 1,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    user_id: row.user_id,
+  };
+}
+
+function normalizePagesListResponse(
+  rows: SQLitePageRow[],
+  params: GetPagesParams,
+) {
+  return {
+    success: true as const,
+    data: {
+      training_pages: rows.map((row) => ({
+        page: normalizePageRow(row),
+        tags: [], // PR6 で N+1 解消（ハンドラ側で JOIN）
+        attachments: [], // PR5 で実装
+      })),
+      total_count: rows.length, // 簡易: limit 内の件数。PR6 で正確な総数取得を実装
+      offset: params.offset ?? 0,
+      limit: params.limit ?? rows.length,
+    },
+  };
+}

--- a/frontend/src/lib/hooks/useIsNativeApp.ts
+++ b/frontend/src/lib/hooks/useIsNativeApp.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { isNativeApp } from "@/lib/api/native-bridge";
+
+/**
+ * 現在のレンダリング環境がネイティブアプリ (Expo WebView) かどうかを返す。
+ *
+ * SSR / 初回ハイドレーション時は false を返し、マウント後に
+ * window.__AIKINOTE_NATIVE_APP__ の値で更新する (hydration mismatch を回避)。
+ *
+ * 用途:
+ *   - 統計・カレンダー画面のオフラインガード (Native かつオフライン時のみ表示)
+ *   - 添付フォームの動画選択肢の動的制御
+ */
+export function useIsNativeApp(): boolean {
+  const [native, setNative] = useState(false);
+  useEffect(() => {
+    setNative(isNativeApp());
+  }, []);
+  return native;
+}

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -279,7 +279,8 @@
       "maxCountReached": "Maximum of 5 attachments allowed",
       "note": "Images: JPG/PNG/WebP (max 5MB), Videos: MP4/MOV/WebM (max 300MB), max 5 files",
       "cancelUpload": "Cancel",
-      "youtubeHint": "For long videos, upload to YouTube and paste the URL below"
+      "youtubeHint": "For long videos, upload to YouTube and paste the URL below",
+      "nativeVideoUnavailable": "The app currently supports image attachments only."
     }
   },
   "navigation": {
@@ -1183,5 +1184,9 @@
     "confirm": "Confirm",
     "cancel": "Cancel",
     "processing": "Processing..."
+  },
+  "offlineGuard": {
+    "message": "This feature requires a network connection.",
+    "retry": "Retry"
   }
 }

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -279,7 +279,8 @@
       "maxCountReached": "添付ファイルは5件までです",
       "note": "画像: JPG/PNG/WebP（最大5MB）、動画: MP4/MOV/WebM（最大300MB）、上限5件",
       "cancelUpload": "キャンセル",
-      "youtubeHint": "長い動画はYouTubeにアップロードしてURLを貼り付けてください"
+      "youtubeHint": "長い動画はYouTubeにアップロードしてURLを貼り付けてください",
+      "nativeVideoUnavailable": "アプリ版では現在、画像のみ添付できます"
     }
   },
   "navigation": {
@@ -1185,5 +1186,9 @@
     "confirm": "確定",
     "cancel": "キャンセル",
     "processing": "処理中..."
+  },
+  "offlineGuard": {
+    "message": "ネットワークが接続されている状態でしかご利用いただけません",
+    "retry": "再試行"
   }
 }


### PR DESCRIPTION
## Summary

「ひとりで」(personal pages) のオフラインファースト化 **PR3/6**。aikinote (Web) 側で Native SQLite ブリッジを呼ぶための部品を揃え、統計・カレンダーにオフラインガード画面を組み込みます。

Native 側の PR1 (Tomoya-Sonok/aikinote-native-app#4) と PR2 (Tomoya-Sonok/aikinote-native-app#5) に対応する Web 側の実装です。

## 変更内容

### 1. `lib/api/native-bridge.ts` (新規)
- `callPersonalBridge<T>(type, payload, options)` — Promise ベースで Native に PERSONAL_* を投げる
- 既存 IAP / OAuth で確立済みの `window.__onNativeMessage` ハンドラを **ラップ** して、PERSONAL_*_RESULT だけ自前 `pending` map で resolve。それ以外 (IAP_RESULT / SUBSCRIPTION_STATUS / OAUTH_RESULT) は既存ハンドラに委譲
- `BridgeCallError` (code/message)、TIMEOUT (15s デフォルト)、`isNativeApp()`

### 2. `lib/api/personal-adapter.ts` (新規)
- 既存 `client.ts` は無変更、その上に `isNative ? bridge_call : remote_call` の薄い切替層を新設
- `bridgeOrRemote` ヘルパで `NOT_IMPLEMENTED` / `NO_BRIDGE` 時に remote (tRPC) フォールバック → PR4 (同期) / PR5 (画像) 未着でも安全
- 対象: `getPages` / `getPage` / `createPage` / `updatePage` / `deletePage` / `togglePageVisibility` / `getTags` / `createTag` / `getCategories`
- **本 PR ではフックからの import 切替はしません**（PR6 で初回プル完成後に集約）

### 3. `lib/hooks/useIsNativeApp.ts` (新規)
- SSR 安全な `isNativeApp()` の React Hook ラッパ（初回は false、マウント後に判定）

### 4. `components/shared/OfflineGuard/` (新規)
- Phosphor `WifiSlashIcon` (64px) + 「ネットワークが接続されている状態でしかご利用いただけません」+ 再試行ボタン
- CSS Modules、translations 追加 (`offlineGuard.message` / `offlineGuard.retry`)
- `<output role="status">` で a11y 対応

### 5. 統計・カレンダーにガード組込
- `personal/stats/PersonalStats.tsx` — `isNative && !isOnline` で OfflineGuard 表示。すべての hooks 呼び出し後に early return（hook 順序保護）
- `personal/calendar/PersonalCalendar.tsx` — 同上

Web ブラウザでは `isNative=false` なので従来通り動作（影響なし）。

### 6. `AttachmentUpload.tsx`
- ネイティブアプリでは `accept` から動画 (mp4/quicktime/webm) を除外し画像のみに
- `VideoCamera` アイコンを非表示にして UI 上「画像のみ」のように見せる
- 「アプリ版では現在、画像のみ添付できます」Tooltip
- Web ブラウザは従来通り動画 OK

## Test plan

- [x] `pnpm check` (Biome) 通過
- [x] `pnpm tsc --noEmit` 通過
- [x] `pnpm test` — 38 files / **294 tests** 全パス（新規追加 10 tests 含む）
  - `native-bridge.test.ts` (8): isNativeApp / postMessage / 既存ハンドラ温存 / ok=false / TIMEOUT
  - `OfflineGuard.test.tsx` (2): メッセージ + 再試行ボタン

### 動作確認の想定
- [ ] Web ブラウザで `/personal/stats` `/personal/calendar` がこれまで通り動作
- [ ] Web ブラウザでページ作成画面の添付がこれまで通り (画像+動画) 動作
- [ ] ネイティブアプリの Airplane Mode で `/personal/stats` `/personal/calendar` を開くと OfflineGuard が表示される
- [ ] ネイティブアプリでページ作成画面の添付ボタンが画像のみ受け付ける（動画選択肢が出ない）

## ロードマップ

| PR | 内容 | 状況 |
|---|---|---|
| PR1 | ブリッジ基盤 | ✅ Merged |
| PR2 | SQLite スキーマ + CRUD | ✅ Merged |
| **PR3 (本 PR)** | Web adapter + OfflineGuard + 動画排除 | ← 提出中 |
| PR4 | Pull/Push 同期エンジン (LWW) | 次 |
| PR5 | 画像オフライン (FS + S3 キュー) | |
| PR6 | 初回フルプル + 進捗 UI + フック import 差し替え | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)