### PR TITLE
feat(native-bridge): USER_INFO に Supabase の access_token を含める

### DIFF
--- a/frontend/src/lib/hooks/useAuth.tsx
+++ b/frontend/src/lib/hooks/useAuth.tsx
@@ -217,24 +217,56 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [supabase]);
 
-  // ネイティブアプリにユーザー情報を通知（認証状態変化時）
+  // ネイティブアプリにユーザー情報を通知（認証状態変化時）。
+  // ネイティブ側は受信した access_token を supabase.auth.setSession に渡し、
+  // SQLite ↔ Supabase の同期 (RLS 越し) で利用する。WebView ↔ Native は同一
+  // プロセス間のメッセージで外部に出ないため、token をそのまま渡してよい。
   useEffect(() => {
-    if (
-      typeof window !== "undefined" &&
-      (window as any).__AIKINOTE_NATIVE_APP__ &&
-      (window as any).ReactNativeWebView
-    ) {
-      (window as any).ReactNativeWebView.postMessage(
+    if (typeof window === "undefined") return;
+    const win = window as typeof window & {
+      __AIKINOTE_NATIVE_APP__?: boolean;
+      ReactNativeWebView?: { postMessage: (msg: string) => void };
+    };
+    if (!win.__AIKINOTE_NATIVE_APP__ || !win.ReactNativeWebView) return;
+
+    let cancelled = false;
+    const send = async () => {
+      let accessToken: string | null = null;
+      let refreshToken: string | null = null;
+      let expiresAt: number | null = null;
+      if (user) {
+        try {
+          const { data } = await supabase.auth.getSession();
+          accessToken = data.session?.access_token ?? null;
+          refreshToken = data.session?.refresh_token ?? null;
+          expiresAt = data.session?.expires_at ?? null;
+        } catch (error) {
+          console.warn(
+            "[useAuth] supabase.auth.getSession の取得に失敗:",
+            error,
+          );
+        }
+      }
+      if (cancelled || !win.ReactNativeWebView) return;
+      win.ReactNativeWebView.postMessage(
         JSON.stringify({
           type: "USER_INFO",
           payload: {
             profileImageUrl: user?.profile_image_url ?? null,
             userId: user?.id ?? null,
+            accessToken,
+            refreshToken,
+            expiresAt,
           },
         }),
       );
-    }
-  }, [user]);
+    };
+
+    void send();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, supabase]);
 
   const signUp = useCallback(
     async (data: SignUpFormData): Promise<SignUpResponse> => {


### PR DESCRIPTION
## Summary

ネイティブアプリ (Expo WebView ラッパー) の **SQLite ↔ Supabase 同期エンジン** (aikinote-native-app PR #6) が、Web 側で取得済みの Supabase auth セッションを利用できるよう、既存の `USER_INFO` postMessage に **`access_token` / `refresh_token` / `expires_at`** を含めます。

Native 側は受信した token を `supabase.auth.setSession` に渡して RLS 越しの sync を実行します（別 PR で対応予定）。

## 変更箇所

`frontend/src/lib/hooks/useAuth.tsx` の「ネイティブアプリにユーザー情報を通知」useEffect を拡張:
- `supabase.auth.getSession()` を呼んで現セッションを取得
- `USER_INFO` payload に 3 フィールド (`accessToken` / `refreshToken` / `expiresAt`) を追加
- 既存の `userId` / `profileImageUrl` フィールドは変更なし → Native 側の受信箇所と完全に後方互換
- `as any` を排除し `typeof window & { ... }` 型に整理

## 挙動

| 環境 | 影響 |
|---|---|
| Web ブラウザ | `window.__AIKINOTE_NATIVE_APP__` が undefined なので useEffect が早期 return → postMessage 実行されず、影響ゼロ |
| ネイティブアプリ (旧ビルド) | 受信側で 3 フィールドを参照しないだけで動作。token は未使用のまま捨てられる |
| ネイティブアプリ (新ビルド、別 PR 適用後) | 受信した token で `supabase.auth.setSession` し、RLS 越しの sync が動く |

## セキュリティ

WebView ↔ Native のメッセージは同一プロセス間で完結し、外部 (ネットワーク / 他アプリ) には出ません。Supabase の access_token は通常 1 時間有効、refresh_token は機密性が高いですが、ネイティブアプリ自身が `expo-secure-store` 等で保持するのと同等のセキュリティレベルです。

## Test plan

- [x] `pnpm check` (Biome) 通過
- [x] `pnpm tsc --noEmit` 通過
- [x] `pnpm test` — 全テスト pass
- [ ] Web ブラウザで動作確認 (auth flow に regression なし)
- [ ] ネイティブアプリの旧ビルドでの動作確認 (token フィールドを無視して既存 userId 処理が動く)

## 関連

- 受信側: aikinote-native-app の別 PR で `setSession` 配線予定
- 同期エンジン: Tomoya-Sonok/aikinote-native-app#6 (PR4/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)