### PR TITLE
feat(personal): フックを adapter 経由に切替 + SyncStatusBanner (PR6-Web/6)

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/edit/PageEdit.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/edit/PageEdit.tsx
@@ -16,7 +16,9 @@ import { TextArea } from "@/components/shared/TextArea/TextArea";
 import { TextInput } from "@/components/shared/TextInput/TextInput";
 import { MAX_CATEGORIES } from "@/constants/tags";
 import { useToast } from "@/contexts/ToastContext";
-import { updatePage } from "@/lib/api/client";
+// 「ひとりで」のページ更新はネイティブ環境では SQLite (adapter 経由) に
+// 切り替わる。Web ブラウザでは isNative=false なので従来通り tRPC 経由。
+import { updatePage } from "@/lib/api/personal-adapter";
 import { useAttachmentManagement } from "@/lib/hooks/useAttachmentManagement";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useBeforeUnload } from "@/lib/hooks/useBeforeUnload";

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/new/PageCreate.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/new/PageCreate.tsx
@@ -19,9 +19,11 @@ import { MAX_CATEGORIES, type TagLanguage } from "@/constants/tags";
 import { useToast } from "@/contexts/ToastContext";
 import {
   type CreatePagePayload,
-  createPage,
   upsertTrainingDateAttendance,
 } from "@/lib/api/client";
+// 「ひとりで」のページ作成はネイティブ環境では SQLite (adapter 経由) に
+// 切り替わる。Web ブラウザでは isNative=false なので従来通り tRPC 経由。
+import { createPage } from "@/lib/api/personal-adapter";
 import { useAttachmentManagement } from "@/lib/hooks/useAttachmentManagement";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useBeforeUnload } from "@/lib/hooks/useBeforeUnload";

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { OfflineBanner } from "@/components/shared/OfflineBanner/OfflineBanner";
 import { FontSizeProvider } from "@/components/shared/providers/FontSizeProvider";
 import { LocaleInitializer } from "@/components/shared/providers/LocaleInitializer";
 import { QueryProvider } from "@/components/shared/providers/QueryProvider";
+import { SyncStatusBanner } from "@/components/shared/SyncStatusBanner";
 import { ToastProvider } from "@/contexts/ToastContext";
 import { AuthProvider } from "@/lib/hooks/useAuth";
 import { routing } from "@/lib/i18n/routing";
@@ -46,6 +47,7 @@ export default async function LocaleLayout({
             <AuthProvider>
               <GlobalFetchIndicator />
               <OfflineBanner />
+              <SyncStatusBanner />
               <main
                 style={{ background: "var(--bg-base)", minHeight: "100vh" }}
               >

--- a/frontend/src/components/shared/SyncStatusBanner/SyncStatusBanner.module.css
+++ b/frontend/src/components/shared/SyncStatusBanner/SyncStatusBanner.module.css
@@ -1,0 +1,44 @@
+.banner {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--white);
+  color: var(--text-light);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  font-size: var(--font-size-xs);
+  z-index: var(--z-toast);
+  max-width: calc(100vw - 32px);
+  pointer-events: none;
+}
+
+.banner.error {
+  background: var(--white);
+  color: var(--error-color);
+  border-color: var(--error-color);
+}
+
+.message {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spinning {
+  animation: sync-banner-spin 1s linear infinite;
+}
+
+@keyframes sync-banner-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/components/shared/SyncStatusBanner/SyncStatusBanner.tsx
+++ b/frontend/src/components/shared/SyncStatusBanner/SyncStatusBanner.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { ArrowsClockwiseIcon, WarningIcon } from "@phosphor-icons/react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import {
+  addSyncStatusListener,
+  type SyncStatusPayload,
+} from "@/lib/api/native-bridge";
+import { useIsNativeApp } from "@/lib/hooks/useIsNativeApp";
+import styles from "./SyncStatusBanner.module.css";
+
+/**
+ * ネイティブアプリ限定: 同期エンジン (PR4 + PR6) の進捗バナー。
+ *
+ * 表示条件:
+ *   - 同期が走り始めて running になったとき
+ *   - failed のとき
+ *   - completed 後、しばらく (3秒) 表示してから自動で消える
+ *
+ * Web ブラウザでは isNative=false なので何も表示しない。
+ */
+export function SyncStatusBanner() {
+  const isNative = useIsNativeApp();
+  const t = useTranslations("syncStatus");
+  const [status, setStatus] = useState<SyncStatusPayload | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isNative) return;
+
+    const unsubscribe = addSyncStatusListener((next) => {
+      setStatus(next);
+      if (next.state === "running" || next.state === "failed") {
+        setVisible(true);
+      } else if (next.state === "completed") {
+        setVisible(true);
+        // 3 秒で消す
+        window.setTimeout(() => setVisible(false), 3000);
+      } else {
+        setVisible(false);
+      }
+    });
+    return unsubscribe;
+  }, [isNative]);
+
+  if (!isNative || !visible || !status) return null;
+
+  const message = (() => {
+    if (status.state === "running") return t("running");
+    if (status.state === "completed") return t("completed");
+    if (status.state === "failed")
+      return status.error ? `${t("failed")} (${status.error})` : t("failed");
+    return null;
+  })();
+  if (!message) return null;
+
+  const isError = status.state === "failed";
+  return (
+    <output
+      className={`${styles.banner} ${isError ? styles.error : ""}`}
+      aria-live="polite"
+    >
+      {isError ? (
+        <WarningIcon size={16} weight="bold" aria-hidden="true" />
+      ) : (
+        <ArrowsClockwiseIcon
+          size={16}
+          weight="regular"
+          aria-hidden="true"
+          className={status.state === "running" ? styles.spinning : ""}
+        />
+      )}
+      <span className={styles.message}>{message}</span>
+    </output>
+  );
+}

--- a/frontend/src/components/shared/SyncStatusBanner/index.ts
+++ b/frontend/src/components/shared/SyncStatusBanner/index.ts
@@ -1,0 +1,1 @@
+export { SyncStatusBanner } from "./SyncStatusBanner";

--- a/frontend/src/lib/api/native-bridge.ts
+++ b/frontend/src/lib/api/native-bridge.ts
@@ -69,6 +69,27 @@ type PendingResolver = (response: BridgeResponse<unknown>) => void;
 const pending = new Map<string, PendingResolver>();
 let handlerInstalled = false;
 
+// PERSONAL_SYNC_STATUS の back-channel 通知 (Native → Web) を受け取るリスナ。
+// SyncStatusBanner など UI 側で addSyncStatusListener を購読する。
+export interface SyncStatusPayload {
+  state: "idle" | "running" | "completed" | "failed";
+  scope?: "full" | "incremental" | "push-only";
+  pending?: number;
+  error?: string;
+}
+type SyncStatusListener = (status: SyncStatusPayload) => void;
+const syncStatusListeners = new Set<SyncStatusListener>();
+
+export function addSyncStatusListener(
+  listener: SyncStatusListener,
+): () => void {
+  syncStatusListeners.add(listener);
+  installResultHandler();
+  return () => {
+    syncStatusListeners.delete(listener);
+  };
+}
+
 export function isNativeApp(): boolean {
   if (typeof window === "undefined") return false;
   return !!(window as NativeWindow).__AIKINOTE_NATIVE_APP__;
@@ -118,6 +139,23 @@ function installResultHandler(): void {
           return;
         }
       }
+    }
+
+    // PERSONAL_SYNC_STATUS は back-channel (request/response 対ではない)。
+    // requestId は無いので、リスナ全員に配信する。
+    if (msg?.type === "PERSONAL_SYNC_STATUS") {
+      const status = msg.payload as SyncStatusPayload | undefined;
+      if (status) {
+        // Array.from で snapshot を作って iterate (TS の downlevelIteration 警告を回避)
+        for (const listener of Array.from(syncStatusListeners)) {
+          try {
+            listener(status);
+          } catch (error) {
+            console.warn("[native-bridge] SyncStatusListener エラー:", error);
+          }
+        }
+      }
+      return;
     }
 
     // PERSONAL 以外 (IAP / SUBSCRIPTION_STATUS / OAUTH_RESULT 等) は既存 handler に委譲
@@ -207,5 +245,6 @@ export async function callPersonalBridge<T = unknown>(
  */
 export function _resetBridgeForTest(): void {
   pending.clear();
+  syncStatusListeners.clear();
   handlerInstalled = false;
 }

--- a/frontend/src/lib/hooks/usePageDetailData.ts
+++ b/frontend/src/lib/hooks/usePageDetailData.ts
@@ -1,7 +1,13 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import type { AttachmentData } from "@/components/features/personal/AttachmentCard/AttachmentCard";
-import { getAttachments, getPage } from "@/lib/api/client";
+// 「ひとりで」のページ詳細はネイティブ環境では SQLite (adapter 経由) に
+// 切り替わる。Web ブラウザでは isNative=false なので従来通り tRPC 経由。
+// 添付ファイルは PR5 (画像オフライン) と PR6 でブリッジ対応するが、現状は
+// 引き続き既存 client の getAttachments を使う (Native 環境では adapter 内で
+// remote へフォールバック)。
+import { getAttachments } from "@/lib/api/client";
+import { getPage } from "@/lib/api/personal-adapter";
 import { useAuth } from "@/lib/hooks/useAuth";
 import type { TrainingPageData } from "@/types/training";
 

--- a/frontend/src/lib/hooks/useTrainingPagesData.ts
+++ b/frontend/src/lib/hooks/useTrainingPagesData.ts
@@ -8,7 +8,9 @@ import {
 import { useTranslations } from "next-intl";
 import { useCallback, useMemo } from "react";
 import { useToast } from "@/contexts/ToastContext";
-import { deletePage, getPages } from "@/lib/api/client";
+// 「ひとりで」のページ取得・削除はネイティブ環境では SQLite (adapter 経由) に
+// 切り替わる。Web ブラウザでは isNative=false なので従来通り tRPC 経由。
+import { deletePage, getPages } from "@/lib/api/personal-adapter";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { formatToLocalDateString } from "@/lib/utils/dateUtils";
 import { getNetworkAwareErrorMessage } from "@/lib/utils/offlineError";

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -1188,5 +1188,10 @@
   "offlineGuard": {
     "message": "This feature requires a network connection.",
     "retry": "Retry"
+  },
+  "syncStatus": {
+    "running": "Syncing…",
+    "completed": "Sync completed",
+    "failed": "Sync failed"
   }
 }

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -1190,5 +1190,10 @@
   "offlineGuard": {
     "message": "ネットワークが接続されている状態でしかご利用いただけません",
     "retry": "再試行"
+  },
+  "syncStatus": {
+    "running": "同期しています…",
+    "completed": "同期が完了しました",
+    "failed": "同期に失敗しました"
   }
 }


### PR DESCRIPTION
## Summary

「ひとりで」(personal pages) のオフラインファースト化 **PR6-Web/6**。aikinote-native-app PR #9 (Pull + PERSONAL_SYNC_STATUS) と合わせてマージすることで、Web 側でもネイティブ環境では SQLite 経由でページ操作が動くようになります。

これで PR1〜PR6 と auth-token 配信を合わせた **全 6 段階の構成が揃います**。

## 変更内容

### 1. フックの import を `personal-adapter.ts` 経由に差し替え

Web ブラウザでは `isNative=false` で従来通り tRPC 直通、ネイティブ環境では SQLite ブリッジに切替:

- `lib/hooks/useTrainingPagesData.ts` — `deletePage` / `getPages`
- `lib/hooks/usePageDetailData.ts` — `getPage` (添付ファイルは引き続き client 経由)
- `app/.../personal/pages/new/PageCreate.tsx` — `createPage`
- `app/.../personal/pages/[page_id]/edit/PageEdit.tsx` — `updatePage`

タグ / カテゴリ / 添付 (Web 側の作成・削除) は引き続き client 直通。ネイティブ環境で adapter フォールバックが remote に通すため動作には影響ありません。

### 2. `lib/api/native-bridge.ts` に sync status リスナを追加

- `SyncStatusPayload` 型と `addSyncStatusListener(listener)` を export
- `__onNativeMessage` 内で `PERSONAL_SYNC_STATUS` をリスナ全員に配信
- back-channel メッセージ (requestId 無し) として既存 IAP / OAuth resolver と干渉しない

### 3. `components/shared/SyncStatusBanner/` (新規)

- Phosphor `ArrowsClockwise` (回転) / `Warning` を使った控えめなバナー
- `running` 中は表示、`completed` で 3 秒後に自動消失、`failed` は明示まで残る
- `isNative=false` (Web ブラウザ) では何も表示しない
- `app/[locale]/layout.tsx` の `AuthProvider` 下に挿入

### 4. translations

新規キー: `syncStatus.running` / `completed` / `failed` (ja / en)

## マージで揃う体験

PR1〜PR5、auth-token (#304, #7)、PR6-Native (#9) が揃った状態でこの PR をマージすると、ネイティブアプリで:

1. 起動時、Supabase 既存データを SQLite に **full pull**
2. ページ作成 / 編集 / 削除はオフラインで **即時 SQLite に反映**
3. ネット接続中はバックグラウンドで **Supabase と双方向 LWW 同期**
4. 進捗は **SyncStatusBanner** で控えめに通知
5. 統計 / カレンダーはオフライン時 **OfflineGuard** で利用不可表示
6. 画像はオフラインで **Native FS に保存** + ネット復帰で S3 へ

## Test plan

- [x] `pnpm check` (Biome) 通過
- [x] `pnpm typecheck` (tsc --noEmit) 通過
- [x] `pnpm vitest` — 関連テスト (native-bridge / OfflineGuard) pass
- [ ] Web ブラウザで `/personal/pages` の一覧・作成・編集・削除が従来通り動作 (regression なし)
- [ ] ネイティブビルドで Airplane Mode → ページ作成・編集・削除が即時、ネット復帰で Supabase に反映

## ロードマップ (完了)

| PR | 内容 | 状況 |
|---|---|---|
| PR1〜PR5 + auth-token | 各層の実装 | ✅ Merged / In Review |
| PR6-Native (#9) | Pull + PERSONAL_SYNC_STATUS | 🟡 In Review |
| **PR6-Web (本 PR)** | フック切替 + SyncStatusBanner | ← 提出中 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)