### PR TITLE
feat(personal): タグ/カテゴリ/公開切替のオフラインガードと案内 Toast を追加

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/(tabbed)/(default-header)/personal/pages/[page_id]/PageDetail.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/(tabbed)/(default-header)/personal/pages/[page_id]/PageDetail.tsx
@@ -12,7 +12,9 @@ import { Tag } from "@/components/shared/Tag/Tag";
 import { useToast } from "@/contexts/ToastContext";
 import { deletePage, togglePageVisibility } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
+import { useOnlineStatus } from "@/lib/hooks/useOnlineStatus";
 import { usePageDetailData } from "@/lib/hooks/usePageDetailData";
+import { useRequireOnline } from "@/lib/hooks/useRequireOnline";
 import { useSubscription } from "@/lib/hooks/useSubscription";
 
 import { useRouter } from "@/lib/i18n/routing";
@@ -43,6 +45,8 @@ export function PageDetail() {
   const [isTogglingPublic, setTogglingPublic] = useState(false);
   const { isPremium } = useSubscription();
   const [showPremiumModal, setShowPremiumModal] = useState(false);
+  const isOnline = useOnlineStatus();
+  const requireOnline = useRequireOnline();
 
   const handleBackToList = () => {
     router.push("/personal/pages");
@@ -50,6 +54,9 @@ export function PageDetail() {
 
   const handleTogglePublic = async () => {
     if (!pageData || !user?.id || isTogglingPublic) return;
+
+    // 公開切替は Supabase 必須操作。オフライン時は Toast で案内して中断
+    if (!requireOnline()) return;
 
     // Free ユーザーが ON にしようとした場合は PremiumUpgradeModal を表示
     if (!pageData.is_public && !isPremium) {
@@ -283,7 +290,7 @@ export function PageDetail() {
           </div>
         )}
 
-        {/* 公開範囲設定 */}
+        {/* 公開範囲設定 (Supabase 必須操作なのでオフライン時は disabled) */}
         <div className={styles.publicToggle}>
           <label className={styles.toggleLabel}>
             <span>{t("pageDetail.publicToggle")}</span>
@@ -291,8 +298,13 @@ export function PageDetail() {
               type="button"
               role="switch"
               aria-checked={pageData.is_public}
+              aria-disabled={!isOnline}
               className={`${styles.toggle} ${pageData.is_public ? styles.toggleOn : ""}`}
               onClick={handleTogglePublic}
+              disabled={!isOnline || isTogglingPublic}
+              title={
+                !isOnline ? t("offlineGuard.actionRequiresNetwork") : undefined
+              }
             >
               <span className={styles.toggleKnob} />
             </button>

--- a/frontend/src/app/[locale]/(authenticated)/(tabbed)/(default-header)/personal/pages/[page_id]/page.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/(tabbed)/(default-header)/personal/pages/[page_id]/page.module.css
@@ -248,6 +248,11 @@
   background: var(--active-color);
 }
 
+.toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .toggleKnob {
   position: absolute;
   top: 2px;

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/edit/PageEdit.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/edit/PageEdit.tsx
@@ -22,6 +22,7 @@ import { updatePage } from "@/lib/api/personal-adapter";
 import { useAttachmentManagement } from "@/lib/hooks/useAttachmentManagement";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useBeforeUnload } from "@/lib/hooks/useBeforeUnload";
+import { useOnlineStatus } from "@/lib/hooks/useOnlineStatus";
 import { usePageDetailData } from "@/lib/hooks/usePageDetailData";
 import { useTagManagement } from "@/lib/hooks/useTagManagement";
 import { useTrainingTags } from "@/lib/hooks/useTrainingTags";
@@ -55,6 +56,7 @@ export function PageEdit() {
 
   // タグ管理
   const tagManagement = useTagManagement();
+  const isOnline = useOnlineStatus();
 
   // カテゴリ追加
   const [showAddCategory, setShowAddCategory] = useState(false);
@@ -347,7 +349,14 @@ export function PageEdit() {
                   variant="primary"
                   size="small"
                   onClick={handleAddCategory}
-                  disabled={isCreatingCategory || !newCategoryInput.trim()}
+                  disabled={
+                    isCreatingCategory || !newCategoryInput.trim() || !isOnline
+                  }
+                  title={
+                    !isOnline
+                      ? t("offlineGuard.actionRequiresNetwork")
+                      : undefined
+                  }
                 >
                   {t("pageModal.add")}
                 </Button>
@@ -357,7 +366,12 @@ export function PageEdit() {
                 type="button"
                 className={styles.addCategoryButton}
                 onClick={() => setShowAddCategory(true)}
-                disabled={!canAddCategory}
+                disabled={!canAddCategory || !isOnline}
+                title={
+                  !isOnline
+                    ? t("offlineGuard.actionRequiresNetwork")
+                    : undefined
+                }
               >
                 <PlusCircle size={16} weight="light" />
                 {t("tagManagement.addCategory")}

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/new/PageCreate.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/new/PageCreate.tsx
@@ -27,6 +27,7 @@ import { createPage } from "@/lib/api/personal-adapter";
 import { useAttachmentManagement } from "@/lib/hooks/useAttachmentManagement";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useBeforeUnload } from "@/lib/hooks/useBeforeUnload";
+import { useOnlineStatus } from "@/lib/hooks/useOnlineStatus";
 import { useTagManagement } from "@/lib/hooks/useTagManagement";
 import { useRouter } from "@/lib/i18n/routing";
 import { formatToLocalDateString } from "@/lib/utils/dateUtils";
@@ -56,6 +57,7 @@ export function PageCreate() {
 
   const tagManagement = useTagManagement();
   const attachmentMgmt = useAttachmentManagement("page");
+  const isOnline = useOnlineStatus();
 
   // カテゴリ追加
   const [showAddCategory, setShowAddCategory] = useState(false);
@@ -348,7 +350,14 @@ export function PageCreate() {
                   variant="primary"
                   size="small"
                   onClick={handleAddCategory}
-                  disabled={isCreatingCategory || !newCategoryInput.trim()}
+                  disabled={
+                    isCreatingCategory || !newCategoryInput.trim() || !isOnline
+                  }
+                  title={
+                    !isOnline
+                      ? t("offlineGuard.actionRequiresNetwork")
+                      : undefined
+                  }
                 >
                   {t("pageModal.add")}
                 </Button>
@@ -358,7 +367,12 @@ export function PageCreate() {
                 type="button"
                 className={styles.addCategoryButton}
                 onClick={() => setShowAddCategory(true)}
-                disabled={!canAddCategory}
+                disabled={!canAddCategory || !isOnline}
+                title={
+                  !isOnline
+                    ? t("offlineGuard.actionRequiresNetwork")
+                    : undefined
+                }
               >
                 <PlusCircle size={16} weight="light" />
                 {t("tagManagement.addCategory")}

--- a/frontend/src/app/[locale]/(authenticated)/settings/tags/TagManagement.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/settings/tags/TagManagement.tsx
@@ -29,6 +29,8 @@ import {
   updateTagOrder,
 } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
+import { useOnlineStatus } from "@/lib/hooks/useOnlineStatus";
+import { useRequireOnline } from "@/lib/hooks/useRequireOnline";
 import type { UserCategory } from "@/types/category";
 import styles from "./TagManagement.module.css";
 
@@ -106,6 +108,8 @@ export function TagManagement({ locale }: TagManagementProps) {
   const t = useTranslations();
   const { showToast } = useToast();
   const { user } = useAuth();
+  const isOnline = useOnlineStatus();
+  const requireOnline = useRequireOnline();
 
   const [categories, setCategories] = useState<UserCategory[]>([]);
   const [tagGroups, setTagGroups] = useState<TagGroupMap>({});
@@ -240,6 +244,7 @@ export function TagManagement({ locale }: TagManagementProps) {
       showToast(t("tagManagement.authRequired"), "error");
       return;
     }
+    if (!requireOnline()) return;
 
     const inputValue = (newTagInputs[category] ?? "").trim();
 
@@ -297,6 +302,7 @@ export function TagManagement({ locale }: TagManagementProps) {
     if (!user?.id || deletingTagId) {
       return;
     }
+    if (!requireOnline()) return;
 
     setDeletingTagId(tagId);
 
@@ -521,6 +527,7 @@ export function TagManagement({ locale }: TagManagementProps) {
 
   const handleSaveOrder = async (category: string) => {
     if (!user?.id || !hasOrderChanged(category)) return;
+    if (!requireOnline()) return;
 
     const payload: UpdateTagOrderPayload = {
       user_id: user.id,
@@ -560,6 +567,7 @@ export function TagManagement({ locale }: TagManagementProps) {
   // カテゴリ操作
   const handleCreateCategory = async () => {
     if (!user?.id) return;
+    if (!requireOnline()) return;
     const trimmed = newCategoryInput.trim();
     if (!trimmed) return;
     if (trimmed.length > 10) {
@@ -612,6 +620,7 @@ export function TagManagement({ locale }: TagManagementProps) {
 
   const handleSaveEditCategory = async () => {
     if (!user?.id || !editingCategoryId) return;
+    if (!requireOnline()) return;
     const trimmed = editCategoryInput.trim();
     if (!trimmed || trimmed.length > 10) return;
 
@@ -645,6 +654,7 @@ export function TagManagement({ locale }: TagManagementProps) {
 
   const handleConfirmDeleteCategory = async () => {
     if (!user?.id || !deleteCategoryTarget) return;
+    if (!requireOnline()) return;
 
     setIsDeletingCategory(true);
     try {
@@ -725,7 +735,12 @@ export function TagManagement({ locale }: TagManagementProps) {
                           variant="primary"
                           size="small"
                           onClick={handleSaveEditCategory}
-                          disabled={!editCategoryInput.trim()}
+                          disabled={!editCategoryInput.trim() || !isOnline}
+                          title={
+                            !isOnline
+                              ? t("offlineGuard.actionRequiresNetwork")
+                              : undefined
+                          }
                         >
                           {t("tagManagement.saveOrder")}
                         </Button>
@@ -743,6 +758,12 @@ export function TagManagement({ locale }: TagManagementProps) {
                             className={styles.categoryEditButton}
                             onClick={() => handleStartEditCategory(cat)}
                             aria-label={`Edit category ${cat.name}`}
+                            disabled={!isOnline}
+                            title={
+                              !isOnline
+                                ? t("offlineGuard.actionRequiresNetwork")
+                                : undefined
+                            }
                           >
                             <PencilSimple size={16} />
                           </button>
@@ -751,6 +772,12 @@ export function TagManagement({ locale }: TagManagementProps) {
                             className={styles.categoryDeleteButton}
                             onClick={() => setDeleteCategoryTarget(cat)}
                             aria-label={`Delete category ${cat.name}`}
+                            disabled={!isOnline}
+                            title={
+                              !isOnline
+                                ? t("offlineGuard.actionRequiresNetwork")
+                                : undefined
+                            }
                           >
                             <Trash size={16} color="var(--error-color)" />
                           </button>
@@ -759,7 +786,12 @@ export function TagManagement({ locale }: TagManagementProps) {
                               variant="primary"
                               size="small"
                               onClick={() => handleSaveOrder(cat.name)}
-                              disabled={!orderChanged || isSaving}
+                              disabled={!orderChanged || isSaving || !isOnline}
+                              title={
+                                !isOnline
+                                  ? t("offlineGuard.actionRequiresNetwork")
+                                  : undefined
+                              }
                             >
                               {isSaving
                                 ? t("tagManagement.orderSaving")
@@ -838,6 +870,12 @@ export function TagManagement({ locale }: TagManagementProps) {
                                   handleDeleteTag(cat.name, tag.id)
                                 }
                                 aria-label={`Delete tag ${tag.name}`}
+                                disabled={!isOnline}
+                                title={
+                                  !isOnline
+                                    ? t("offlineGuard.actionRequiresNetwork")
+                                    : undefined
+                                }
                               >
                                 <X
                                   size={12}
@@ -879,7 +917,12 @@ export function TagManagement({ locale }: TagManagementProps) {
                       variant="primary"
                       size="small"
                       onClick={() => handleCreateTag(cat.name)}
-                      disabled={isSubmitting || !inputValue.trim()}
+                      disabled={isSubmitting || !inputValue.trim() || !isOnline}
+                      title={
+                        !isOnline
+                          ? t("offlineGuard.actionRequiresNetwork")
+                          : undefined
+                      }
                     >
                       {t("pageModal.add")}
                     </Button>
@@ -910,7 +953,13 @@ export function TagManagement({ locale }: TagManagementProps) {
                   disabled={
                     isCreatingCategory ||
                     !newCategoryInput.trim() ||
-                    remainingCategories <= 0
+                    remainingCategories <= 0 ||
+                    !isOnline
+                  }
+                  title={
+                    !isOnline
+                      ? t("offlineGuard.actionRequiresNetwork")
+                      : undefined
                   }
                 >
                   {t("tagManagement.addCategory")}

--- a/frontend/src/components/shared/TagSectionWithNewInput/TagSectionWithNewInput.tsx
+++ b/frontend/src/components/shared/TagSectionWithNewInput/TagSectionWithNewInput.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/shared/Button/Button";
 import { TagSelection } from "@/components/shared/TagSelection/TagSelection";
+import { useOnlineStatus } from "@/lib/hooks/useOnlineStatus";
 import type { UseTagManagementReturn } from "@/lib/hooks/useTagManagement";
 import styles from "./TagSectionWithNewInput.module.css";
 
@@ -24,6 +25,7 @@ export function TagSectionWithNewInput({
   tagManagement,
 }: TagSectionWithNewInputProps) {
   const t = useTranslations();
+  const isOnline = useOnlineStatus();
 
   const displayTitle = title ?? (titleKey ? t(titleKey) : category);
 
@@ -55,7 +57,12 @@ export function TagSectionWithNewInput({
             size="small"
             onClick={() => tagManagement.handleSubmitNewTag(category)}
             disabled={
-              tagManagement.loading || !tagManagement.newTagInput.trim()
+              tagManagement.loading ||
+              !tagManagement.newTagInput.trim() ||
+              !isOnline
+            }
+            title={
+              !isOnline ? t("offlineGuard.actionRequiresNetwork") : undefined
             }
           >
             {t("pageModal.add")}

--- a/frontend/src/lib/api/personal-adapter.ts
+++ b/frontend/src/lib/api/personal-adapter.ts
@@ -202,18 +202,11 @@ export async function togglePageVisibility(
   userId: string,
   isPublic: boolean,
 ) {
-  return bridgeOrRemote(
-    async () => {
-      await callPersonalBridge<{ localId: string; isPublic: boolean }>(
-        "PERSONAL_PAGES_TOGGLE_VISIBILITY",
-        { pageId, userId, isPublic },
-      );
-      return { success: true } as unknown as RemoteResult<
-        typeof remote.togglePageVisibility
-      >;
-    },
-    () => remote.togglePageVisibility(pageId, userId, isPublic),
-  );
+  // 公開切替はネットワーク必須仕様 (UI 側で useRequireOnline によりガード済み)。
+  // SQLite ローカル更新は行わず、必ず Supabase に PUT する。
+  // PERSONAL_PAGES_TOGGLE_VISIBILITY ハンドラ自体は後方互換 + 将来再利用のため
+  // Native 側に残してあるが、Web からは呼ばない。
+  return remote.togglePageVisibility(pageId, userId, isPublic);
 }
 
 // ============================== Tags ==============================

--- a/frontend/src/lib/hooks/useRequireOnline.test.tsx
+++ b/frontend/src/lib/hooks/useRequireOnline.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useRequireOnline } from "./useRequireOnline";
+
+const showToastMock = vi.fn();
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+const messages = {
+  offlineGuard: {
+    actionRequiresNetwork: "この操作はネットに接続してからお試しください",
+  },
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="ja" messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
+
+const setOnlineForTest = (online: boolean) => {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value: online,
+  });
+  window.dispatchEvent(new Event(online ? "online" : "offline"));
+};
+
+describe("useRequireOnline", () => {
+  beforeEach(() => {
+    showToastMock.mockReset();
+  });
+
+  afterEach(() => {
+    setOnlineForTest(true);
+  });
+
+  it("オンライン時は true を返して Toast を出さない", () => {
+    // Arrange
+    setOnlineForTest(true);
+    const { result } = renderHook(() => useRequireOnline(), { wrapper });
+
+    // Act
+    let ok = false;
+    act(() => {
+      ok = result.current();
+    });
+
+    // Assert
+    expect(ok).toBe(true);
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
+  it("オフライン時は false を返して Toast を出す", () => {
+    // Arrange
+    const { result, rerender } = renderHook(() => useRequireOnline(), {
+      wrapper,
+    });
+    act(() => {
+      setOnlineForTest(false);
+    });
+    rerender();
+
+    // Act
+    let ok = true;
+    act(() => {
+      ok = result.current();
+    });
+
+    // Assert
+    expect(ok).toBe(false);
+    expect(showToastMock).toHaveBeenCalledWith(
+      "この操作はネットに接続してからお試しください",
+      "info",
+    );
+  });
+});

--- a/frontend/src/lib/hooks/useRequireOnline.ts
+++ b/frontend/src/lib/hooks/useRequireOnline.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback } from "react";
+import { useToast } from "@/contexts/ToastContext";
+import { useOnlineStatus } from "@/lib/hooks/useOnlineStatus";
+
+/**
+ * 「ネット接続必須」操作の入口で 1 行ガードするためのヘルパフック。
+ *
+ * 使い方:
+ *   const requireOnline = useRequireOnline();
+ *   const handleCreate = async () => {
+ *     if (!requireOnline()) return; // オフライン時は Toast 表示 + false 返却
+ *     ...
+ *   };
+ *
+ * Toast variant は既存実装 ("success" | "error" | "info") のうち、
+ * 「エラーではなく注意喚起」レベルとして "info" を使う。
+ */
+export function useRequireOnline(): () => boolean {
+  const isOnline = useOnlineStatus();
+  const { showToast } = useToast();
+  const t = useTranslations("offlineGuard");
+
+  return useCallback(() => {
+    if (isOnline) return true;
+    showToast(t("actionRequiresNetwork"), "info");
+    return false;
+  }, [isOnline, showToast, t]);
+}

--- a/frontend/src/lib/hooks/useTagManagement.ts
+++ b/frontend/src/lib/hooks/useTagManagement.ts
@@ -15,6 +15,7 @@ import {
   initializeUserTags,
 } from "@/lib/api/client";
 import { useAuth } from "@/lib/hooks/useAuth";
+import { useRequireOnline } from "@/lib/hooks/useRequireOnline";
 import { trainingTagsQueryKey } from "@/lib/hooks/useTrainingTags";
 import type { UserCategory } from "@/types/category";
 
@@ -79,6 +80,9 @@ export function useTagManagement(
   const t = useTranslations();
   const { showToast } = useToast();
   const queryClient = useQueryClient();
+  // タグ/カテゴリの mutation はオフラインでは tRPC が動かないので、
+  // 関数層でも二重防御として requireOnline でガードする。
+  const requireOnline = useRequireOnline();
 
   // カテゴリ / タグは TanStack Query に任せる。
   // /personal/pages で `useTrainingTags` が事前にタグをキャッシュしていれば、
@@ -137,6 +141,9 @@ export function useTagManagement(
   const initializeTags = useCallback(
     async (language: TagLanguage) => {
       if (!user?.id) return;
+      // 初期タグ投入は現在の仕様どおりネット必須。オフライン時は requireOnline で
+      // ガードして Toast を出す。
+      if (!requireOnline()) return;
       try {
         await initializeUserTags(user.id, language);
         await invalidateTagsAndCategories();
@@ -144,7 +151,7 @@ export function useTagManagement(
         showToast(t("pageModal.tagAddFailed"), "error");
       }
     },
-    [user?.id, showToast, t, invalidateTagsAndCategories],
+    [user?.id, showToast, t, invalidateTagsAndCategories, requireOnline],
   );
 
   // タグをカテゴリ別に分類
@@ -212,6 +219,7 @@ export function useTagManagement(
 
   const handleCreateTag = useCallback(
     async (tagData: CreateTagPayload) => {
+      if (!requireOnline()) return;
       try {
         const response = await createTag(tagData);
         if (response.success && response.data) {
@@ -232,7 +240,7 @@ export function useTagManagement(
         );
       }
     },
-    [queryClient, user?.id, showToast, t, handleTagToggle],
+    [queryClient, user?.id, showToast, t, handleTagToggle, requireOnline],
   );
 
   const handleSubmitNewTag = useCallback(
@@ -269,6 +277,7 @@ export function useTagManagement(
   const handleCreateCategory = useCallback(
     async (name: string) => {
       if (!user?.id) return;
+      if (!requireOnline()) return;
       if (categories.length >= MAX_CATEGORIES) {
         showToast(
           t("tagManagement.categoryLimitReached", { max: MAX_CATEGORIES }),
@@ -305,7 +314,7 @@ export function useTagManagement(
         );
       }
     },
-    [user?.id, categories.length, queryClient, showToast, t],
+    [user?.id, categories.length, queryClient, showToast, t, requireOnline],
   );
 
   return {

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -1187,7 +1187,8 @@
   },
   "offlineGuard": {
     "message": "This feature requires a network connection.",
-    "retry": "Retry"
+    "retry": "Retry",
+    "actionRequiresNetwork": "This action requires a network connection. Please reconnect and try again."
   },
   "syncStatus": {
     "running": "Syncing…",

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -1189,7 +1189,8 @@
   },
   "offlineGuard": {
     "message": "ネットワークが接続されている状態でしかご利用いただけません",
-    "retry": "再試行"
+    "retry": "再試行",
+    "actionRequiresNetwork": "この操作はネットに接続してからお試しください"
   },
   "syncStatus": {
     "running": "同期しています…",


### PR DESCRIPTION
## Summary

「ひとりで」のオフラインファースト化 (PR1〜PR6) では未対応だった以下に **ネット必須ガード** を追加し、ユーザーに明示的にフィードバックします。

| 項目 | Before | After |
|---|---|---|
| タグ追加 / 削除 / 並べ替え | オフライン時に tRPC 失敗 (原因不明エラー) | ボタン disabled + Toast「ネットに接続してから...」 |
| カテゴリ追加 / 編集 / 削除 | 同上 | 同上 |
| 公開切替 (`togglePageVisibility`) | Native で SQLite 更新で動いてしまう | **ネット必須に仕様変更** + disabled + Toast |

## 変更内容

### 1. `lib/hooks/useRequireOnline.ts` (新規)
- mutation 入口で 1 行ガードする共通フック
- オフラインなら `showToast("info")` を出して `false` 返却
- vitest 単体テスト同梱

### 2. 翻訳キー追加
- `offlineGuard.actionRequiresNetwork`
  - ja: 「この操作はネットに接続してからお試しください」
  - en: "This action requires a network connection. Please reconnect and try again."

### 3. タグ/カテゴリ操作のガード
- `useTagManagement.ts`: `initializeTags` / `handleCreateTag` / `handleCreateCategory` の入口に `requireOnline()`
- `TagSectionWithNewInput.tsx`: タグ追加ボタンに `disabled` + `title`
- `TagManagement.tsx` (settings/tags): タグ追加 / 削除 / 並べ替え保存、カテゴリ追加 / 編集保存 / 削除のすべてのボタンに `disabled` + `title`、各 mutation 関数の入口にも `requireOnline()`
- `PageCreate.tsx` / `PageEdit.tsx`: カテゴリ追加ボタンに `disabled` + `title`

### 4. 公開切替の仕様変更
- `PageDetail.tsx`: トグルに `disabled` + `title` + `aria-disabled`、`handleTogglePublic` 入口に `requireOnline()`
- `page.module.css`: `.toggle:disabled` スタイル追加
- **`personal-adapter.ts` の `togglePageVisibility` を bridge 経由から remote 直行に変更** — SQLite ローカル更新は行わず、必ず Supabase に PUT。`PERSONAL_PAGES_TOGGLE_VISIBILITY` ハンドラ自体は後方互換のため Native 側に残してあるが Web からは呼ばれなくなる

## Test plan

- [x] `pnpm check` (Biome) 通過
- [x] `pnpm typecheck` (tsc --noEmit) 通過
- [x] `pnpm test` — 39 files / **296 tests** 全パス（`useRequireOnline.test.tsx` 2 件追加）
- [ ] DevTools の Offline モードで `/personal/pages` / `/personal/pages/[id]` / `/settings/tags` の対象ボタンが disabled + Toast 表示されること
- [ ] オンライン復帰後に全部動作復帰
- [ ] Web ブラウザでもネイティブアプリでも、ページ本体 (タイトル/本文) のオフライン読み書きは変わらず動くこと (regression なし)

## スコープ外

- 添付ファイル (`getAttachments` / `createAttachment` / 削除) のオフライン対応 — 別 PR で対応
- `OfflineHint` インライン警告との併用 — Toast に統一して UI 散らかりを防止
- `Toast` の `warning` variant 新設 — 既存 `info` で代替

🤖 Generated with [Claude Code](https://claude.com/claude-code)