### PR TITLE
fix(useAuth): 初期化中の偽 null USER_INFO 送信を抑止 (緊急、強制ログアウト回避)

### DIFF
--- a/frontend/src/lib/hooks/useAuth.tsx
+++ b/frontend/src/lib/hooks/useAuth.tsx
@@ -221,6 +221,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // ネイティブ側は受信した access_token を supabase.auth.setSession に渡し、
   // SQLite ↔ Supabase の同期 (RLS 越し) で利用する。WebView ↔ Native は同一
   // プロセス間のメッセージで外部に出ないため、token をそのまま渡してよい。
+  //
+  // ⚠️ 重要: 初期化中 (isInitializing=true) の偽 null は送らない。
+  // useAuth の初期 state は user=null / isInitializing=true で始まり、その後
+  // session を取得して setUser する。本 effect の依存に user を入れているため
+  // 初期 mount 時に「user=null」の USER_INFO が一度発火してしまう。Native 側
+  // (旧版含む) はそれを「ログアウト」と誤認して supabase.auth.signOut() を
+  // 呼び、サーバー側 session を破棄するため、数秒後に WebView の token refresh
+  // が 401 になって強制ログアウトされる。Vercel に本変更が乗ると旧 build (#25)
+  // でも問題が解消する。
   useEffect(() => {
     if (typeof window === "undefined") return;
     const win = window as typeof window & {
@@ -228,6 +237,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       ReactNativeWebView?: { postMessage: (msg: string) => void };
     };
     if (!win.__AIKINOTE_NATIVE_APP__ || !win.ReactNativeWebView) return;
+    if (isInitializing) return;
 
     let cancelled = false;
     const send = async () => {
@@ -266,7 +276,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [user, supabase]);
+  }, [user, supabase, isInitializing]);
 
   const signUp = useCallback(
     async (data: SignUpFormData): Promise<SignUpResponse> => {


### PR DESCRIPTION
## Summary 
ユーザーが Android build #25 を実機で動作確認したところ、**ログイン後しばらくすると強制的にログイン画面へリダイレクト** される不具合が発覚。本 PR は **Vercel に乗ると build #25 のままでも即時解消** する Web 側の修正です。

## 原因

\`useAuth\` の useEffect が \`[user, supabase]\` 依存で \`USER_INFO\` を送信するが、初期 state が \`user=null / isInitializing=true\` で始まるため、**初回 mount 時に「userId: null」の USER_INFO が 1 回発火** していました。

Native 側 (\`aikinote-native-app/app/index.tsx:529\`) はそれをログアウトと誤認して \`supabase.auth.signOut()\` を呼びますが、Supabase JS の \`signOut()\` は **デフォルトで scope: 'global'** のためサーバー側で refresh_token が無効化されます。結果、数秒後の WebView 側 token refresh が 401 となり強制ログアウトに至ります。

メール / パスワードでも Google OAuth (\`startNativeOAuth("google")\`) でも経路は同じです。

## 修正

\`useAuth.tsx\` の USER_INFO 送信 useEffect:

```tsx
useEffect(() => {
  ...
  if (!win.__AIKINOTE_NATIVE_APP__ || !win.ReactNativeWebView) return;
  if (isInitializing) return;   // ← 追加: 初期化完了まで送信抑止
  ...
}, [user, supabase, isInitializing]);  // ← 依存配列に isInitializing 追加
```

これで \`isInitializing: true → false\` 遷移が完了し \`user\` が確定してから初めて USER_INFO が送られます。

## 即時効果

本 PR が Vercel にデプロイされると、**現在の Android build #25 のままでも** 問題が解消します:
- Web 側で偽 null を送らなくなる → Native 側の \`signOut()\` が発火しない → サーバー側 session 破棄が起きない → 強制ログアウト不発生

## 補完 PR (別途)

Native 側でも二重防御として \`signOut()\` 呼び出し自体を削除する PR を別途出します (aikinote-native-app)。あちらは次の build (#26) に乗せる予定。同期エラー (「同期に失敗しました (pullCategories...)」) は Native 側でしか直せないので、それも同 PR で同時対応。

## Test plan

- [x] \`pnpm check\` 通過
- [x] \`pnpm typecheck\` 通過
- [ ] Vercel preview で `__AIKINOTE_NATIVE_APP__` フラグ立てて DevTools から確認するか、Native アプリで実機確認
- [ ] Web ブラウザでログイン挙動に regression なし (\`__AIKINOTE_NATIVE_APP__\` が undefined なので early return)

🤖 Generated with [Claude Code](https://claude.com/claude-code)