### PR TITLE
fix(personal): 同期完了時にひとりで関連 TanStack Query を invalidate

### DIFF
--- a/frontend/src/components/shared/SyncStatusBanner/SyncStatusBanner.tsx
+++ b/frontend/src/components/shared/SyncStatusBanner/SyncStatusBanner.tsx
@@ -8,6 +8,7 @@ import {
   type SyncStatusPayload,
 } from "@/lib/api/native-bridge";
 import { useIsNativeApp } from "@/lib/hooks/useIsNativeApp";
+import { useSyncQueryInvalidator } from "@/lib/hooks/useSyncQueryInvalidator";
 import styles from "./SyncStatusBanner.module.css";
 
 /**
@@ -22,6 +23,8 @@ import styles from "./SyncStatusBanner.module.css";
  */
 export function SyncStatusBanner() {
   const isNative = useIsNativeApp();
+  // Pull 完了で関連 TanStack Query を invalidate (race condition 対策)
+  useSyncQueryInvalidator();
   const t = useTranslations("syncStatus");
   const [status, setStatus] = useState<SyncStatusPayload | null>(null);
   const [visible, setVisible] = useState(false);

--- a/frontend/src/lib/hooks/useSyncQueryInvalidator.test.tsx
+++ b/frontend/src/lib/hooks/useSyncQueryInvalidator.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetBridgeForTest } from "@/lib/api/native-bridge";
+import { useSyncQueryInvalidator } from "./useSyncQueryInvalidator";
+
+const useIsNativeAppMock = vi.fn<() => boolean>(() => true);
+vi.mock("@/lib/hooks/useIsNativeApp", () => ({
+  useIsNativeApp: () => useIsNativeAppMock(),
+}));
+
+interface TestWindow {
+  __onNativeMessage?: (msg: unknown) => void;
+}
+const getTestWindow = (): TestWindow => window as unknown as TestWindow;
+
+function emitSyncStatus(payload: unknown) {
+  getTestWindow().__onNativeMessage?.({
+    type: "PERSONAL_SYNC_STATUS",
+    payload,
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useSyncQueryInvalidator", () => {
+  let queryClient: QueryClient;
+  let invalidateSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetBridgeForTest();
+    delete getTestWindow().__onNativeMessage;
+    useIsNativeAppMock.mockReturnValue(true);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { gcTime: Number.POSITIVE_INFINITY, retry: false },
+      },
+    });
+    invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  });
+
+  afterEach(() => {
+    invalidateSpy.mockRestore();
+    _resetBridgeForTest();
+    delete getTestWindow().__onNativeMessage;
+  });
+
+  it("Native + completed/full で 7 種類の queryKey を invalidate する", () => {
+    // Arrange
+    renderHook(() => useSyncQueryInvalidator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    // Act
+    act(() => {
+      emitSyncStatus({ state: "completed", scope: "full" });
+    });
+
+    // Assert
+    expect(invalidateSpy).toHaveBeenCalledTimes(7);
+    const calledKeys = invalidateSpy.mock.calls.map(
+      ([arg]) => (arg as { queryKey: string[] }).queryKey[0],
+    );
+    expect(calledKeys).toEqual([
+      "training-pages",
+      "training-pages-unfiltered-count",
+      "training-tags",
+      "training-categories",
+      "training-stats",
+      "page-detail",
+      "page-attachments",
+    ]);
+  });
+
+  it("scope: 'push-only' では invalidate されない", () => {
+    // Arrange
+    renderHook(() => useSyncQueryInvalidator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    // Act
+    act(() => {
+      emitSyncStatus({ state: "completed", scope: "push-only" });
+    });
+
+    // Assert
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("state: 'running' / 'failed' では invalidate されない", () => {
+    // Arrange
+    renderHook(() => useSyncQueryInvalidator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    // Act
+    act(() => {
+      emitSyncStatus({ state: "running", scope: "full" });
+    });
+    act(() => {
+      emitSyncStatus({ state: "failed", scope: "full", error: "any" });
+    });
+
+    // Assert
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("isNative=false ならリスナーを登録せず invalidate も発火しない", () => {
+    // Arrange
+    useIsNativeAppMock.mockReturnValue(false);
+    renderHook(() => useSyncQueryInvalidator(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    // Act
+    act(() => {
+      emitSyncStatus({ state: "completed", scope: "full" });
+    });
+
+    // Assert
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("unmount でリスナーが解除される", () => {
+    // Arrange
+    const { unmount } = renderHook(() => useSyncQueryInvalidator(), {
+      wrapper: createWrapper(queryClient),
+    });
+    unmount();
+
+    // Act
+    act(() => {
+      emitSyncStatus({ state: "completed", scope: "full" });
+    });
+
+    // Assert
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/hooks/useSyncQueryInvalidator.ts
+++ b/frontend/src/lib/hooks/useSyncQueryInvalidator.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { addSyncStatusListener } from "@/lib/api/native-bridge";
+import { useIsNativeApp } from "@/lib/hooks/useIsNativeApp";
+
+// Pull で更新されうる「ひとりで」関連 TanStack Query の prefix 一覧。
+// invalidateQueries は prefix match (exact: false がデフォルト) で動くので、
+// 各フックの完全 queryKey (userId 等の suffix 付き) も網羅される。
+const PERSONAL_SYNC_QUERY_KEYS: ReadonlyArray<readonly string[]> = [
+  ["training-pages"],
+  ["training-pages-unfiltered-count"],
+  ["training-tags"],
+  ["training-categories"],
+  ["training-stats"],
+  ["page-detail"],
+  ["page-attachments"],
+];
+
+/**
+ * Native (Expo WebView) で同期エンジンが Pull を含む sync を完了した際、
+ * 「ひとりで」関連の TanStack Query キャッシュをまとめて invalidate する hook。
+ *
+ * 目的:
+ *   起動時の race condition で発生する「Web 側が SQLite 空キャッシュを表示し続ける」
+ *   現象を解消する。Pull 完了 (PERSONAL_SYNC_STATUS: completed) を契機に refetch を促す。
+ *
+ * 配線:
+ *   SyncStatusBanner 内で 1 度だけ呼び出すことを想定 (banner は layout に常駐)。
+ *   push-only scope は Pull が走っていないので invalidate しない。
+ */
+export function useSyncQueryInvalidator() {
+  const isNative = useIsNativeApp();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!isNative) return;
+    return addSyncStatusListener((status) => {
+      if (status.state !== "completed") return;
+      if (status.scope === "push-only") return;
+      for (const queryKey of PERSONAL_SYNC_QUERY_KEYS) {
+        queryClient.invalidateQueries({ queryKey: [...queryKey] });
+      }
+    });
+  }, [isNative, queryClient]);
+}


### PR DESCRIPTION
## Summary

- Native アプリ起動時に「同期しています」と表示されるが、Supabase に既存ページがある状態でログインしても **「まだページが作成されていません。」と表示される** 不具合を解消
- 根本原因: WebView ロード後 Web 側 `useTrainingPagesData` が **Pull 完了前に SQLite を SELECT して空キャッシュを掴む** race condition。`SyncStatusBanner` が完了通知を受け取っても `invalidateQueries` を呼んでいなかった
- 修正: 新 hook `useSyncQueryInvalidator` を `SyncStatusBanner` から 1 行で呼ぶ。`PERSONAL_SYNC_STATUS { state: 'completed' }` (push-only 以外) で「ひとりで」関連 7 種類の query prefix を invalidate
- Native 側 build #26 は維持。Web 側 Vercel デプロイのみで修正完結

## 修正詳細

- 新規 `frontend/src/lib/hooks/useSyncQueryInvalidator.ts`
- `frontend/src/components/shared/SyncStatusBanner/SyncStatusBanner.tsx` に hook 呼び出し 1 行追加
- vitest 5 ケース (Native + completed/full、push-only、running/failed、isNative=false、unmount)

### Invalidate 対象 query prefix

| prefix | 同期対象 |
|---|---|
| `["training-pages"]` | training_pages 一覧 |
| `["training-pages-unfiltered-count"]` | フィルタなし総件数 |
| `["training-tags"]` | user_tags |
| `["training-categories"]` | user_categories |
| `["training-stats"]` | 集計 (派生) |
| `["page-detail"]` | training_pages 単体 |
| `["page-attachments"]` | page_attachments |

## Test plan

- [x] `pnpm vitest run src/lib/hooks/useSyncQueryInvalidator.test.tsx` → 5/5 passed
- [x] `pnpm test` (frontend 全体) → 301/301 passed
- [x] `pnpm check` → 新規/修正ファイルに警告なし (既存警告のみ)
- [x] `pnpm tsc --noEmit` → no errors
- [ ] 実機テスト (Vercel デプロイ後): アプリ完全終了 → データ消去 → 再起動 → ログイン → ページ一覧で同期完了後に既存ページが画面遷移なしで出現
- [ ] タグ管理画面でも Supabase の既存タグが反映されることを確認
- [ ] mutation 後 (ページ作成/編集) の push-only 同期で過剰な再フェッチが起きないことを確認

## スコープ外

- `personal-adapter.ts:310` の `total_count: rows.length` 問題 → Native 側ハンドラ追加が必要なので別 PR (build #27 待ち)
- `PersonalCalendar.tsx` の TanStack Query 化 → 別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)