### PR TITLE
feat(personal): ネイティブアプリでも動画添付を許可 + PageAttachment.updated_at 追加

### DIFF
--- a/backend/src/lib/supabase.ts
+++ b/backend/src/lib/supabase.ts
@@ -1276,6 +1276,7 @@ export interface PageAttachmentRow {
   file_size_bytes: number | null; // ファイルサイズ（バイト）
   sort_order: number; // 表示順
   created_at: string; // timestamp
+  updated_at?: string; // timestamptz (migration 026 — DB 上は必須だが既存コード互換のため optional)
 }
 
 // ページ添付一覧取得関数

--- a/backend/src/migrations/026_add_updated_at_to_page_attachment.sql
+++ b/backend/src/migrations/026_add_updated_at_to_page_attachment.sql
@@ -1,0 +1,26 @@
+-- マイグレーション 026: PageAttachment テーブルに updated_at カラムを追加
+--
+-- 背景:
+--   ネイティブアプリ版 AikiNote の SQLite × Supabase 同期エンジンで
+--   pullAttachments を追加する。LWW (Last-Write-Wins) 競合解決のため
+--   PageAttachment から updated_at を SELECT する必要があるが、
+--   現状の Supabase スキーマには updated_at カラムが無いため、
+--   migration 025 と同じパターンで追加する。
+--
+-- 方針:
+--   ADD COLUMN IF NOT EXISTS で非破壊的に追加し、既存行は
+--   created_at の値で埋め戻す。BEFORE UPDATE トリガーで自動更新。
+--   set_updated_at_to_now() は migration 025 で定義済み。
+
+ALTER TABLE "PageAttachment"
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+UPDATE "PageAttachment"
+SET updated_at = created_at
+WHERE updated_at IS DISTINCT FROM created_at;
+
+DROP TRIGGER IF EXISTS trigger_page_attachment_updated_at ON "PageAttachment";
+CREATE TRIGGER trigger_page_attachment_updated_at
+  BEFORE UPDATE ON "PageAttachment"
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at_to_now();

--- a/frontend/src/components/features/personal/AttachmentUpload/AttachmentUpload.tsx
+++ b/frontend/src/components/features/personal/AttachmentUpload/AttachmentUpload.tsx
@@ -5,17 +5,15 @@ import { useTranslations } from "next-intl";
 import type { FC } from "react";
 import { useCallback, useRef, useState } from "react";
 import { ATTACHMENT_MAX_COUNT } from "@/lib/aws-s3";
-import { useIsNativeApp } from "@/lib/hooks/useIsNativeApp";
 import { compressImage } from "@/lib/utils/compressImage";
 import type { AttachmentData } from "../AttachmentCard/AttachmentCard";
 import { AttachmentCard } from "../AttachmentCard/AttachmentCard";
 import styles from "./AttachmentUpload.module.css";
 
-// Web ブラウザでは画像 + 動画を受け付ける。ネイティブアプリ (Expo WebView) では
-// 動画のオフライン対応がストレージ負担の都合で未実装のため、画像のみに絞る。
-const ACCEPT_WEB =
+// Web ブラウザ・ネイティブアプリともに画像 + 動画を受け付ける。
+// ネイティブはオフライン対応で local FS に DL してキャッシュする (合計 1GB 上限)。
+const ACCEPT_ALL =
   "image/jpeg,image/jpg,image/png,image/webp,video/mp4,video/quicktime,video/webm";
-const ACCEPT_NATIVE = "image/jpeg,image/jpg,image/png,image/webp";
 
 interface AttachmentUploadProps {
   attachments: AttachmentData[];
@@ -51,7 +49,6 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
   uploadType = "page-attachment",
 }) => {
   const t = useTranslations();
-  const isNative = useIsNativeApp();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const xhrRef = useRef<XMLHttpRequest | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -323,7 +320,7 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
         ref={fileInputRef}
         type="file"
         multiple
-        accept={isNative ? ACCEPT_NATIVE : ACCEPT_WEB}
+        accept={ACCEPT_ALL}
         onChange={handleFileSelect}
         disabled={disabled || isUploading || isMaxReached}
         className={styles.hiddenInput}
@@ -336,16 +333,9 @@ export const AttachmentUpload: FC<AttachmentUploadProps> = ({
           className={styles.fileButton}
           onClick={handleUploadClick}
           disabled={disabled || isUploading || isMaxReached}
-          title={
-            isNative
-              ? t("pageModal.attachments.nativeVideoUnavailable")
-              : undefined
-          }
         >
           <ImageIcon size={16} />
-          {/* ネイティブアプリでは動画アップロード未対応 (PR スコープ外) のため
-              VideoCamera アイコンは非表示にして UI を画像のみに見せる */}
-          {!isNative && <VideoCamera size={16} />}
+          <VideoCamera size={16} />
           {t("pageModal.attachments.addFile")}
         </button>
       </div>

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -279,8 +279,7 @@
       "maxCountReached": "Maximum of 5 attachments allowed",
       "note": "Images: JPG/PNG/WebP (max 5MB), Videos: MP4/MOV/WebM (max 300MB), max 5 files",
       "cancelUpload": "Cancel",
-      "youtubeHint": "For long videos, upload to YouTube and paste the URL below",
-      "nativeVideoUnavailable": "The app currently supports image attachments only."
+      "youtubeHint": "For long videos, upload to YouTube and paste the URL below"
     }
   },
   "navigation": {

--- a/frontend/src/translations/ja.json
+++ b/frontend/src/translations/ja.json
@@ -279,8 +279,7 @@
       "maxCountReached": "添付ファイルは5件までです",
       "note": "画像: JPG/PNG/WebP（最大5MB）、動画: MP4/MOV/WebM（最大300MB）、上限5件",
       "cancelUpload": "キャンセル",
-      "youtubeHint": "長い動画はYouTubeにアップロードしてURLを貼り付けてください",
-      "nativeVideoUnavailable": "アプリ版では現在、画像のみ添付できます"
+      "youtubeHint": "長い動画はYouTubeにアップロードしてURLを貼り付けてください"
     }
   },
   "navigation": {


### PR DESCRIPTION
## Summary

- ネイティブアプリ側で添付ファイルのオフライン対応（pull + ローカルダウンロード + LRU 1GB）を実装したため、Web 版 UI で「ネイティブは画像のみ」と制限していた箇所を解除
- ネイティブアプリの pullAttachments で SELECT する PageAttachment.updated_at を Supabase に追加 (migration 026)

## 関連 PR

- aikinote-native-app: https://github.com/Tomoya-Sonok/aikinote-native-app/pull/11
- 本 PR の migration 026 を本番DBに適用してから native-app PR をリリースする順序

## 変更内容

### Commit 1: `fix(sync)` — migration 026（`8eb25e8`）

- `backend/src/migrations/026_add_updated_at_to_page_attachment.sql`: PageAttachment テーブルに `updated_at TIMESTAMPTZ` を ADD COLUMN IF NOT EXISTS で追加。既存行は `created_at` で埋め戻し。BEFORE UPDATE トリガーで自動更新（`set_updated_at_to_now()` は migration 025 で定義済み）
- `backend/src/lib/supabase.ts`: PageAttachmentRow に `updated_at?: string` を optional として追加

### Commit 2: `feat(personal)` — Web 版 動画キャプチャ許可（`4cf3294`）

- `AttachmentUpload.tsx`: `accept` を `ACCEPT_WEB` / `ACCEPT_NATIVE` の二分岐から `ACCEPT_ALL` に統合（mp4/quicktime/webm を含む）。`useIsNativeApp` の参照を削除
- VideoCamera アイコンを常時表示、ネイティブ用 tooltip を削除
- `frontend/src/translations/{ja,en}.json`: `pageModal.attachments.nativeVideoUnavailable` キーを削除

## Test plan

- [x] `pnpm tsc --noEmit` (frontend) パス
- [x] `pnpm -r check` クリーン
- [ ] **要対応 (本 PR マージ前)**: Supabase 本番DBに `migration 026` を適用
- [ ] Web 版でネイティブアプリ環境（WebView）にて動画をアップロード → /api/page-attachments に POST 成功 → 一覧/詳細で再生できる
- [ ] 既存 Web ブラウザ環境のユーザー導線が壊れていない

## 留意点

- migration 026 は `ADD COLUMN IF NOT EXISTS` の非破壊。本番DB に対しても安全
- 本 PR をマージしても、aikinote-native-app 側 PR をリリースしない限りオフラインダウンロードは動かない（Web 版での動画キャプチャ機能のみ先行リリース可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)