### PR TITLE
fix(personal): MediaPlayer に onError フォールバック追加 + 型コメント訂正

### DIFF
--- a/frontend/src/components/features/personal/MediaPlayer/MediaPlayer.module.css
+++ b/frontend/src/components/features/personal/MediaPlayer/MediaPlayer.module.css
@@ -53,9 +53,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
+  padding: 8px 16px;
   color: var(--text-light);
   font-size: var(--font-size-sm);
   font-family: var(--font-ui);
+  background-color: var(--background-light);
 }
 
 /* 親コンテナがサイズを管理する場合 */

--- a/frontend/src/components/features/personal/MediaPlayer/MediaPlayer.tsx
+++ b/frontend/src/components/features/personal/MediaPlayer/MediaPlayer.tsx
@@ -51,6 +51,11 @@ export const MediaPlayer: FC<MediaPlayerProps> = ({
     [fillParent, onImageLoad],
   );
 
+  const [imageFailed, setImageFailed] = useState(false);
+  const handleImageError = useCallback(() => {
+    setImageFailed(true);
+  }, []);
+
   const containerClass = `${styles.container} ${fillParent ? styles.fillParent : ""} ${isLandscape ? styles.containerLandscape : ""}`;
   const aspectClass = `${styles.aspectRatio} ${fillParent ? styles.fillParentAspect : ""}`;
   if (type === "youtube") {
@@ -93,6 +98,15 @@ export const MediaPlayer: FC<MediaPlayerProps> = ({
   }
 
   // image
+  if (imageFailed || !url) {
+    return (
+      <div className={containerClass}>
+        <div className={aspectClass}>
+          <div className={styles.fallback}>画像を読み込めません</div>
+        </div>
+      </div>
+    );
+  }
   return (
     <div className={containerClass}>
       <div className={aspectClass} style={portraitStyle}>
@@ -103,6 +117,8 @@ export const MediaPlayer: FC<MediaPlayerProps> = ({
           className={`${styles.image} ${isLandscape ? styles.imageLandscape : ""}`}
           sizes="(max-width: 580px) 100vw, 580px"
           onLoad={handleImageLoad}
+          onError={handleImageError}
+          unoptimized={url.startsWith("data:")}
         />
       </div>
     </div>
@@ -128,6 +144,7 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
   aspectClass,
 }) => {
   const [hasEnteredViewport, setHasEnteredViewport] = useState(false);
+  const [videoFailed, setVideoFailed] = useState(false);
   const observerRef = useRef<IntersectionObserver | null>(null);
 
   const setContainerRef = useCallback(
@@ -159,6 +176,16 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
     };
   }, []);
 
+  if (videoFailed || !url) {
+    return (
+      <div className={containerClass}>
+        <div className={aspectClass}>
+          <div className={styles.fallback}>動画を読み込めません</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={containerClass} ref={setContainerRef}>
       <div className={aspectClass}>
@@ -169,6 +196,7 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
           controls
           preload={hasEnteredViewport ? "metadata" : "none"}
           poster={thumbnailUrl ?? undefined}
+          onError={() => setVideoFailed(true)}
         />
       </div>
     </div>

--- a/frontend/src/lib/api/personal-adapter.ts
+++ b/frontend/src/lib/api/personal-adapter.ts
@@ -63,7 +63,10 @@ interface SQLiteCategoryRow {
 
 /**
  * ネイティブ側 handler が shapeAttachmentForWeb で整形して返す添付行。
- * url は local_uri (file://) または remote_url (CloudFront) に解決済み。
+ * url は以下のいずれかに解決済み:
+ *   - 画像でローカルキャッシュあり: `data:<mime>;base64,...` (data URI)
+ *   - 動画 / YouTube / 画像でキャッシュなし: `https://...` (CloudFront / YouTube)
+ * file:// は WebView の https origin から読めないため使わない設計。
  */
 interface SQLiteAttachmentRow {
   local_id: string;


### PR DESCRIPTION
## Summary

ネイティブアプリで「ひとりで」一覧/詳細で画像・動画が **黒い枠 + 壊れたアイコン** で固まる問題への、Web 側からの追加対応。

## 関連 PR

- aikinote-native-app: https://github.com/Tomoya-Sonok/aikinote-native-app/pull/13
  - 根本対応 (添付画像を base64 data URI で返す方式に変更)
  - 本 PR と同時にマージ + リリースする想定

## 変更内容

### `MediaPlayer.tsx`
- 画像 (`<Image>`) と動画 (`<video>`) に `onError` ハンドラを追加。失敗時は **黒い枠で固まる代わりに「画像/動画を読み込めません」のフォールバック UI** を表示
- `url` が空文字列のときも同様にフォールバック UI を表示
- next/image は data URI を渡すと `remotePatterns` 制約に当たるため、`url.startsWith("data:")` のときは `unoptimized` を付ける条件分岐を追加

### `personal-adapter.ts`
- `SQLiteAttachmentRow` のコメントを実態に合わせて訂正
  - 旧: 「url は local_uri (file://) または remote_url (CloudFront) に解決済み」
  - 新: 「画像でローカルキャッシュあり: data:<mime>;base64,... / 動画/YouTube/未キャッシュ: https://...」

### `MediaPlayer.module.css`
- `.fallback` クラスに padding / background-color / text-align を追加してフォールバック UI を見やすく

## 後方互換性

- adapter は data URI / https どちらも `<img src>` に渡すだけなので、ネイティブが古いビルドのままでも壊れません
- 万一 file:// が来たら onError ハンドラが拾って「読み込めません」フォールバック UI が出る

## Test plan

- [x] `pnpm tsc --noEmit` パス
- [x] `pnpm -r check` クリーン（既存 warning のみ、本 PR の変更による新規警告なし）
- [ ] ネイティブアプリ PR とセットでマージ → 実機で画像・動画表示確認
- [ ] Web ブラウザでアクセスして既存挙動が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)