### PR TITLE
fix: Cache Components 環境で公開認証ページがログイン済みでも新規登録画面を表示する問題を修正

### DIFF
--- a/frontend/docs/authentication-system.md
+++ b/frontend/docs/authentication-system.md
@@ -118,7 +118,16 @@ public.User
 
 ### 1. ログインページアクセス
 **場所**: `app/[locale]/(public)/login/page.tsx`
-既にログイン済みの場合はマイページへリダイレクトされます。
+既にログイン済みの場合はマイページへリダイレクトされます。この判定は `GuestGate`
+（`components/shared/auth/GuestGate.tsx`）が担います。
+
+> **⚠️ Cache Components(PPR) 環境での注意**: `GuestGate` は冒頭で `connection()` を呼び、
+> リクエスト毎に必ず認証状態を評価させています。これを怠ると、`cacheComponents: true` 下で
+> 認証チェックを含む公開ページが**未認証状態の静的シェルとしてプリレンダリング**され、
+> ログイン Cookie が有効でも「新規登録 / ログイン画面」が表示されてしまいます
+> （ネイティブアプリは起動時に必ず `/signup` を開くため、再起動の度に新規登録画面が出る不具合に直結しました）。
+> signup / login / forgot-password / reset-password / verify-email / error の各公開認証ページが
+> `GuestGate` でラップされています（認証ロジックが異なる `social/profile` は `connection()` を直接呼んで動的化）。
 
 ### 2. 認証処理 (Supabase)
 Supabase Auth API を叩き、アクセストークンとリフレッシュトークンを取得します。これらは `HttpOnly` Cookie に安全に保存されます。
@@ -375,6 +384,8 @@ if (!user) return <Redirect to="/login" />; // 確定後に判定
 | `frontend/src/lib/supabase/server.ts` | サーバーサイド用 Supabase クライアント |
 | `frontend/src/lib/utils/returnTo.ts` | 認証後リダイレクト（returnTo）ユーティリティ |
 | `frontend/src/lib/hooks/useAuth.tsx` | 認証フック / Context Provider（ログイン・ログアウト・OAuth・3 秒タイムアウト） |
+| `frontend/src/components/shared/auth/AuthGate.tsx` | 認証必須ページ用ゲート。未認証なら `/login` へリダイレクト |
+| `frontend/src/components/shared/auth/GuestGate.tsx` | 公開認証ページ用ゲート。認証済みなら `/personal/pages` へリダイレクト。冒頭の `connection()` で PPR の静的シェル化を抑止 |
 | `frontend/src/server/trpc/index.ts` | tRPC `authenticatedProcedure` — `getUser()` 検証 + 自前 JWT 発行 |
 | `frontend/src/app/auth/callback/route.ts` | OAuth コールバック（セッション交換 + returnTo リダイレクト） |
 | `frontend/src/proxy.ts` | ルーティング保護ミドルウェア (旧 `middleware.ts`)。RSC リクエスト時は getSession スキップ |

--- a/frontend/src/app/[locale]/(public)/error/page.tsx
+++ b/frontend/src/app/[locale]/(public)/error/page.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { GuestGate } from "@/components/shared/auth";
 import { MinimalLayout } from "@/components/shared/layouts/MinimalLayout";
 import { buildMetadata } from "@/lib/metadata";
-import { getCurrentUser } from "@/lib/server/auth";
 import styles from "./page.module.css";
 
 export async function generateMetadata({
@@ -29,12 +28,6 @@ export default async function AuthErrorPage({
 }) {
   const { locale } = await params;
   const resolvedSearchParams = await searchParams;
-  const user = await getCurrentUser();
-
-  if (user) {
-    redirect(`/${locale}/personal/pages`);
-  }
-
   const t = await getTranslations({ locale, namespace: "auth" });
   const error = resolvedSearchParams.error;
   const loginHref = `/${locale}/login`;
@@ -54,55 +47,57 @@ export default async function AuthErrorPage({
   };
 
   return (
-    <MinimalLayout headerTitle={t("authError")} backHref={loginHref}>
-      <div className={styles.container}>
-        <h1 className={styles.title}>{t("authError")}</h1>
+    <GuestGate>
+      <MinimalLayout headerTitle={t("authError")} backHref={loginHref}>
+        <div className={styles.container}>
+          <h1 className={styles.title}>{t("authError")}</h1>
 
-        <div className={styles.formCard}>
-          <div className={styles.errorIcon}>
-            <svg
-              width="48"
-              height="48"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <title>{t("authErrorIcon")}</title>
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L5.351 16.5c-.77.833.192 2.5 1.732 2.5z"
-              />
-            </svg>
-          </div>
-          <h2 className={styles.errorTitle}>{t("authError")}</h2>
-          <p className={styles.errorMessage}>{getErrorMessage(error)}</p>
-
-          {error && (
-            <div className={styles.errorCode}>
-              <p className={styles.errorCodeText}>
-                {t("errorCode")} {error}
-              </p>
+          <div className={styles.formCard}>
+            <div className={styles.errorIcon}>
+              <svg
+                width="48"
+                height="48"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <title>{t("authErrorIcon")}</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.732-.833-2.464 0L5.351 16.5c-.77.833.192 2.5 1.732 2.5z"
+                />
+              </svg>
             </div>
-          )}
+            <h2 className={styles.errorTitle}>{t("authError")}</h2>
+            <p className={styles.errorMessage}>{getErrorMessage(error)}</p>
 
-          <div className={styles.buttonContainer}>
-            <Link
-              href={loginHref}
-              className={`${styles.button} ${styles.primaryButton}`}
-            >
-              {t("backToLogin")}
-            </Link>
-            <Link
-              href={signupHref}
-              className={`${styles.button} ${styles.secondaryButton}`}
-            >
-              {t("signup")}
-            </Link>
+            {error && (
+              <div className={styles.errorCode}>
+                <p className={styles.errorCodeText}>
+                  {t("errorCode")} {error}
+                </p>
+              </div>
+            )}
+
+            <div className={styles.buttonContainer}>
+              <Link
+                href={loginHref}
+                className={`${styles.button} ${styles.primaryButton}`}
+              >
+                {t("backToLogin")}
+              </Link>
+              <Link
+                href={signupHref}
+                className={`${styles.button} ${styles.secondaryButton}`}
+              >
+                {t("signup")}
+              </Link>
+            </div>
           </div>
         </div>
-      </div>
-    </MinimalLayout>
+      </MinimalLayout>
+    </GuestGate>
   );
 }

--- a/frontend/src/app/[locale]/(public)/forgot-password/page.tsx
+++ b/frontend/src/app/[locale]/(public)/forgot-password/page.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { ForgotPasswordForm } from "@/components/features/auth/ForgotPasswordForm";
+import { GuestGate } from "@/components/shared/auth";
 import { MinimalLayout } from "@/components/shared/layouts/MinimalLayout";
 import { buildMetadata } from "@/lib/metadata";
-import { getCurrentUser } from "@/lib/server/auth";
 
 export async function generateMetadata({
   params,
@@ -25,18 +24,14 @@ export default async function ForgotPasswordPage({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const user = await getCurrentUser();
-
-  if (user) {
-    redirect(`/${locale}/personal/pages`);
-  }
-
   const t = await getTranslations({ locale, namespace: "auth" });
   const loginHref = `/${locale}/login`;
 
   return (
-    <MinimalLayout headerTitle={t("passwordResetTitle")} backHref={loginHref}>
-      <ForgotPasswordForm />
-    </MinimalLayout>
+    <GuestGate>
+      <MinimalLayout headerTitle={t("passwordResetTitle")} backHref={loginHref}>
+        <ForgotPasswordForm />
+      </MinimalLayout>
+    </GuestGate>
   );
 }

--- a/frontend/src/app/[locale]/(public)/login/page.tsx
+++ b/frontend/src/app/[locale]/(public)/login/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { GuestGate } from "@/components/shared/auth";
 import { NotLoggedInLayout } from "@/components/shared/layouts/NotLoggedInLayout";
 import { buildMetadata } from "@/lib/metadata";
-import { getCurrentUser } from "@/lib/server/auth";
 import { Login } from "./Login";
 
 export async function generateMetadata({
@@ -25,15 +24,12 @@ export default async function Page({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const user = await getCurrentUser();
-
-  if (user) {
-    redirect(`/${locale}/personal/pages`);
-  }
 
   return (
-    <NotLoggedInLayout>
-      <Login locale={locale} />
-    </NotLoggedInLayout>
+    <GuestGate>
+      <NotLoggedInLayout>
+        <Login locale={locale} />
+      </NotLoggedInLayout>
+    </GuestGate>
   );
 }

--- a/frontend/src/app/[locale]/(public)/reset-password/page.tsx
+++ b/frontend/src/app/[locale]/(public)/reset-password/page.tsx
@@ -1,14 +1,13 @@
 import { WarningCircle } from "@phosphor-icons/react/dist/ssr";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { ResetPasswordForm } from "@/components/features/auth/ResetPasswordForm";
+import { GuestGate } from "@/components/shared/auth";
 import { Loader } from "@/components/shared/Loader";
 import { MinimalLayout } from "@/components/shared/layouts/MinimalLayout";
 import { buildMetadata } from "@/lib/metadata";
-import { getCurrentUser } from "@/lib/server/auth";
 import styles from "./page.module.css";
 
 export async function generateMetadata({
@@ -64,32 +63,28 @@ export default async function ResetPasswordPage({
     params,
     searchParams,
   ]);
-  const user = await getCurrentUser();
-
-  if (user) {
-    redirect(`/${locale}/personal/pages`);
-  }
-
   const t = await getTranslations({ locale });
   const loginHref = `/${locale}/login`;
 
   return (
-    <MinimalLayout
-      headerTitle={t("auth.newPasswordTitle")}
-      backHref={loginHref}
-    >
-      <Suspense
-        fallback={
-          <div className={styles.formCard}>
-            <Loader size="large" centered text={t("auth.loading")} />
-          </div>
-        }
+    <GuestGate>
+      <MinimalLayout
+        headerTitle={t("auth.newPasswordTitle")}
+        backHref={loginHref}
       >
-        <ResetPasswordContent
-          searchParams={resolvedSearchParams}
-          locale={locale}
-        />
-      </Suspense>
-    </MinimalLayout>
+        <Suspense
+          fallback={
+            <div className={styles.formCard}>
+              <Loader size="large" centered text={t("auth.loading")} />
+            </div>
+          }
+        >
+          <ResetPasswordContent
+            searchParams={resolvedSearchParams}
+            locale={locale}
+          />
+        </Suspense>
+      </MinimalLayout>
+    </GuestGate>
   );
 }

--- a/frontend/src/app/[locale]/(public)/signup/page.tsx
+++ b/frontend/src/app/[locale]/(public)/signup/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
+import { GuestGate } from "@/components/shared/auth";
 import { NotLoggedInLayout } from "@/components/shared/layouts/NotLoggedInLayout";
 import { buildMetadata } from "@/lib/metadata";
-import { getCurrentUser } from "@/lib/server/auth";
 import { SignUp } from "./SignUp";
 
 interface SignupPageProps {
@@ -16,15 +15,12 @@ export const metadata: Metadata = buildMetadata({
 
 export default async function Page({ params }: SignupPageProps) {
   const { locale } = await params;
-  const user = await getCurrentUser();
-
-  if (user) {
-    redirect(`/${locale}/personal/pages`);
-  }
 
   return (
-    <NotLoggedInLayout>
-      <SignUp locale={locale} />
-    </NotLoggedInLayout>
+    <GuestGate>
+      <NotLoggedInLayout>
+        <SignUp locale={locale} />
+      </NotLoggedInLayout>
+    </GuestGate>
   );
 }

--- a/frontend/src/app/[locale]/(public)/social/profile/page.tsx
+++ b/frontend/src/app/[locale]/(public)/social/profile/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { connection } from "next/server";
 import { getCurrentUser } from "@/lib/server/auth";
 
 export default async function SocialProfilePage({
@@ -6,6 +7,10 @@ export default async function SocialProfilePage({
 }: {
   params: Promise<{ locale: string }>;
 }) {
+  // Cache Components(PPR)環境では cookies を読むこのページが静的シェル化され、
+  // 認証チェック前に未認証扱いになりうる。connection() で必ずリクエスト時に評価させる。
+  await connection();
+
   const { locale } = await params;
   const user = await getCurrentUser();
 

--- a/frontend/src/app/[locale]/(public)/verify-email/page.tsx
+++ b/frontend/src/app/[locale]/(public)/verify-email/page.tsx
@@ -1,13 +1,12 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { EmailVerificationForm } from "@/components/features/auth/EmailVerificationForm";
+import { GuestGate } from "@/components/shared/auth";
 import { Loader } from "@/components/shared/Loader";
 import { MinimalLayout } from "@/components/shared/layouts/MinimalLayout";
 import { buildMetadata } from "@/lib/metadata";
-import { getCurrentUser } from "@/lib/server/auth";
 import styles from "./page.module.css";
 
 interface VerifyEmailPageProps {
@@ -75,12 +74,6 @@ export default async function VerifyEmailPage({
     params,
     searchParams,
   ]);
-  const user = await getCurrentUser();
-
-  if (user) {
-    redirect(`/${locale}/personal/pages`);
-  }
-
   const t = await getTranslations({
     locale,
     namespace: "auth",
@@ -88,13 +81,17 @@ export default async function VerifyEmailPage({
   const signupHref = `/${locale}/signup`;
 
   return (
-    <MinimalLayout headerTitle={t("emailVerification")} backHref={signupHref}>
-      <Suspense fallback={<Loader size="large" centered text={t("loading")} />}>
-        <EmailVerificationContent
-          searchParams={{ ...resolvedSearchParams, locale }}
-          locale={locale}
-        />
-      </Suspense>
-    </MinimalLayout>
+    <GuestGate>
+      <MinimalLayout headerTitle={t("emailVerification")} backHref={signupHref}>
+        <Suspense
+          fallback={<Loader size="large" centered text={t("loading")} />}
+        >
+          <EmailVerificationContent
+            searchParams={{ ...resolvedSearchParams, locale }}
+            locale={locale}
+          />
+        </Suspense>
+      </MinimalLayout>
+    </GuestGate>
   );
 }

--- a/frontend/src/components/shared/auth/GuestGate.tsx
+++ b/frontend/src/components/shared/auth/GuestGate.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { connection } from "next/server";
+import { getLocale } from "next-intl/server";
+import type { ReactNode } from "react";
+import { getCurrentUser } from "@/lib/server/auth";
+
+interface GuestGateProps {
+  children: ReactNode;
+  /**
+   * 認証済みユーザーのリダイレクト先。未指定時は `/${locale}/personal/pages`。
+   */
+  redirectTo?: string;
+}
+
+/**
+ * 未認証ユーザー専用のゲート。認証済みの場合は redirectTo（既定はマイページ）へリダイレクトする。
+ * 認証必須ページ用の AuthGate と対になる、公開認証ページ（login / signup 等）用のコンポーネント。
+ *
+ * 冒頭で `connection()` を呼ぶことで、Cache Components（PPR）環境でも必ずリクエスト毎に
+ * 認証状態を評価させる。これがないと、認証チェックを含むページが静的シェルとして
+ * プリレンダリングされ、ログイン済みでも「未認証（新規登録 / ログイン画面）」が表示されてしまう
+ * （ネイティブアプリは起動時に必ず /signup を開くため、この事象が毎回発生していた）。
+ */
+export async function GuestGate({ children, redirectTo }: GuestGateProps) {
+  await connection();
+
+  const user = await getCurrentUser();
+  if (user) {
+    const locale = await getLocale();
+    redirect(redirectTo ?? `/${locale}/personal/pages`);
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/shared/auth/index.ts
+++ b/frontend/src/components/shared/auth/index.ts
@@ -1,1 +1,2 @@
 export { AuthGate } from "./AuthGate";
+export { GuestGate } from "./GuestGate";


### PR DESCRIPTION
## 概要
ネイティブアプリ（Expo WebView）で、アプリを閉じて再起動する度に `/signup`（新規登録）画面が表示され、毎回ログインし直す必要がある退行を修正します。Web 版では発生しません。

## 根本原因
Next.js 16 Cache Components(PPR) への移行（`cacheComponents: true`、#275 / 2026-05-04）後、認証必須ページは `AuthGate` で対応されましたが、**公開認証ページ（signup / login 等）は `getCurrentUser()→redirect()` の直書きのまま取り残されていました**。

その結果これらのページが PPR の静的シェル（未認証状態）としてプリレンダリングされ、ネイティブアプリの起動時（必ず `/signup` を開く）に配信されていました。ログイン Cookie 自体は有効なため、ログイン導線を辿れば再入力なしで入れる点も症状と一致します。ビルド出力で該当ページが `◐ Partial Prerender` であることを確認済みです。

- **アプリ版のみ発生** … アプリは起動時に必ず `/signup` を開く（Web は起点にしない）
- **直近で発生** … `cacheComponents: true` 導入（2026-05）
- **Cookie は有効・入力なしで入れる** … ページの認証チェック評価だけが効いていなかった

## 変更内容
- `components/shared/auth/GuestGate.tsx` を新設（`AuthGate` と対称）。冒頭で `connection()` を呼び PPR の静的シェル化を抑止したうえで、認証済みなら `/personal/pages` へリダイレクト
- signup / login / forgot-password / reset-password / verify-email / error の 6 ページを `GuestGate` でラップ
- 認証ロジックの異なる `social/profile` は `connection()` で個別に動的化
- `frontend/docs/authentication-system.md` に方針を追記

## 影響範囲
- **frontend のみ**（Web 側の修正）。Vercel デプロイで既存ネイティブアプリにも反映されます（アプリの再ビルド・再申請は不要）
- 未ログイン時の挙動は従来通り（フォーム表示／初回はチュートリアル）

## 検証
- `pnpm build` 成功 ／ `pnpm check` パス（warning は既存コードのみ）／ `pnpm test:ci` **291 passed**
- **要実機確認**: OAuth（Google / Apple）ログイン済みでアプリを完全終了 → 再起動 → 新規登録画面ではなくホーム（`/personal/pages`）へ着地すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)