### PR TITLE
feat(analytics): AIコーチのクイックアクション計測を追加

### DIFF
--- a/frontend/src/components/features/personal/AiCoach/AiCoachChat.tsx
+++ b/frontend/src/components/features/personal/AiCoach/AiCoachChat.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog/ConfirmDialog";
 import { PremiumUpgradeModal } from "@/components/shared/PremiumUpgradeModal/PremiumUpgradeModal";
 import { useToast } from "@/contexts/ToastContext";
+import type { AiCoachQuickActionId } from "@/lib/aiCoach/constants";
 import {
   type AiCoachConversation,
   createConversation as apiCreateConversation,
@@ -52,13 +53,21 @@ function ChatSession({
   pendingFirstMessage,
   onPendingConsumed,
   onBeforeSend,
+  onQuickActionClick,
   onTitleGenerated,
 }: {
   conversationId: string;
   initialMessages: UIMessage[];
   pendingFirstMessage: string | null;
   onPendingConsumed: () => void;
-  onBeforeSend: (charCount: number, isQuickAction: boolean) => Promise<boolean>;
+  onBeforeSend: (
+    charCount: number,
+    quickActionId: AiCoachQuickActionId | null,
+  ) => Promise<boolean>;
+  onQuickActionClick: (
+    id: AiCoachQuickActionId,
+    source: "landing" | "in_chat",
+  ) => void;
   onTitleGenerated: () => void;
 }) {
   const t = useTranslations();
@@ -110,10 +119,10 @@ function ChatSession({
   }, [pendingFirstMessage, sendMessage, conversationId, onPendingConsumed]);
 
   const send = useCallback(
-    async (text: string, isQuickAction: boolean) => {
+    async (text: string, quickActionId: AiCoachQuickActionId | null) => {
       const trimmed = text.trim();
       if (!trimmed || isBusy) return;
-      const allowed = await onBeforeSend(trimmed.length, isQuickAction);
+      const allowed = await onBeforeSend(trimmed.length, quickActionId);
       if (!allowed) return;
       setInput("");
       void sendMessage({ text: trimmed }, { body: { conversationId } });
@@ -146,7 +155,10 @@ function ChatSession({
         {messages.length === 0 && (
           <QuickActionButtons
             disabled={isBusy}
-            onSelect={(prompt) => send(prompt, true)}
+            onSelect={(id, prompt) => {
+              onQuickActionClick(id, "in_chat");
+              void send(prompt, id);
+            }}
           />
         )}
         <div className={styles.inputRow}>
@@ -164,7 +176,7 @@ function ChatSession({
                 !e.nativeEvent.isComposing
               ) {
                 e.preventDefault();
-                void send(input, false);
+                void send(input, null);
               }
             }}
           />
@@ -172,7 +184,7 @@ function ChatSession({
             type="button"
             className={styles.sendButton}
             disabled={isBusy || !input.trim()}
-            onClick={() => void send(input, false)}
+            onClick={() => void send(input, null)}
             aria-label={t("aiCoach.send")}
           >
             <PaperPlaneRightIcon size={22} weight="fill" />
@@ -190,13 +202,18 @@ function LandingView({
   onDelete,
   onDeleteAll,
   onSend,
+  onQuickActionClick,
   isBusy,
 }: {
   conversations: AiCoachConversation[];
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
   onDeleteAll: () => void;
-  onSend: (text: string, isQuickAction: boolean) => void;
+  onSend: (text: string, quickActionId: AiCoachQuickActionId | null) => void;
+  onQuickActionClick: (
+    id: AiCoachQuickActionId,
+    source: "landing" | "in_chat",
+  ) => void;
   isBusy: boolean;
 }) {
   const t = useTranslations();
@@ -210,11 +227,11 @@ function LandingView({
   }, []);
 
   const handleSend = useCallback(
-    (text: string, isQuickAction: boolean) => {
+    (text: string, quickActionId: AiCoachQuickActionId | null) => {
       const trimmed = text.trim();
       if (!trimmed) return;
       setInput("");
-      onSend(trimmed, isQuickAction);
+      onSend(trimmed, quickActionId);
     },
     [onSend],
   );
@@ -233,7 +250,10 @@ function LandingView({
       <div className={styles.composer}>
         <QuickActionButtons
           disabled={isBusy}
-          onSelect={(prompt) => handleSend(prompt, true)}
+          onSelect={(id, prompt) => {
+            onQuickActionClick(id, "landing");
+            handleSend(prompt, id);
+          }}
         />
         <div className={styles.inputRow}>
           <textarea
@@ -251,7 +271,7 @@ function LandingView({
                 !e.nativeEvent.isComposing
               ) {
                 e.preventDefault();
-                handleSend(input, false);
+                handleSend(input, null);
               }
             }}
           />
@@ -259,7 +279,7 @@ function LandingView({
             type="button"
             className={styles.sendButton}
             disabled={isBusy || !input.trim()}
-            onClick={() => handleSend(input, false)}
+            onClick={() => handleSend(input, null)}
             aria-label={t("aiCoach.send")}
           >
             <PaperPlaneRightIcon size={22} weight="fill" />
@@ -366,9 +386,14 @@ export function AiCoachChat() {
     }
   }, [conversations, showToast, t]);
 
-  // 送信前の利用可否チェック + Umami 計測
+  // 送信前の利用可否チェック + Umami 計測。
+  // quickActionId は固定プロンプト由来のときに識別子（weeklyReview など）が入り、
+  // フリー入力では null。message_send イベントへブレイクダウン用に同梱する。
   const handleBeforeSend = useCallback(
-    async (charCount: number, isQuickAction: boolean): Promise<boolean> => {
+    async (
+      charCount: number,
+      quickActionId: AiCoachQuickActionId | null,
+    ): Promise<boolean> => {
       try {
         const usage = await fetchAiCoachUsage();
         if (!usage.allowed) {
@@ -377,7 +402,8 @@ export function AiCoachChat() {
           return false;
         }
         track("ai_coach_message_send", {
-          is_quick_action: isQuickAction,
+          is_quick_action: quickActionId !== null,
+          quick_action_id: quickActionId,
           char_count: charCount,
         });
         return true;
@@ -389,11 +415,22 @@ export function AiCoachChat() {
     [track, showToast, t],
   );
 
+  // クイックアクションのクリックを利用制限チェック前に計測（クリック意図と送信完遂を分離）
+  const handleQuickActionClick = useCallback(
+    (id: AiCoachQuickActionId, source: "landing" | "in_chat") => {
+      track("ai_coach_quick_action_click", {
+        quick_action_id: id,
+        source,
+      });
+    },
+    [track],
+  );
+
   // landing から送信: 利用可否チェック → 会話の遅延作成 → ChatSession マウントへ pending を渡す
   const handleLandingSend = useCallback(
-    async (text: string, isQuickAction: boolean) => {
+    async (text: string, quickActionId: AiCoachQuickActionId | null) => {
       if (isCreatingFromLanding) return;
-      const allowed = await handleBeforeSend(text.length, isQuickAction);
+      const allowed = await handleBeforeSend(text.length, quickActionId);
       if (!allowed) return;
       setIsCreatingFromLanding(true);
       try {
@@ -448,6 +485,7 @@ export function AiCoachChat() {
           pendingFirstMessage={pendingFirstMessage}
           onPendingConsumed={() => setPendingFirstMessage(null)}
           onBeforeSend={handleBeforeSend}
+          onQuickActionClick={handleQuickActionClick}
           onTitleGenerated={refreshConversations}
         />
       ) : (
@@ -457,6 +495,7 @@ export function AiCoachChat() {
           onDelete={handleDeleteConversation}
           onDeleteAll={() => setShowDeleteAllConfirm(true)}
           onSend={handleLandingSend}
+          onQuickActionClick={handleQuickActionClick}
           isBusy={isCreatingFromLanding}
         />
       )}

--- a/frontend/src/components/features/personal/AiCoach/QuickActionButtons.tsx
+++ b/frontend/src/components/features/personal/AiCoach/QuickActionButtons.tsx
@@ -2,12 +2,16 @@
 
 import { useTranslations } from "next-intl";
 import type { FC } from "react";
-import { AI_COACH_QUICK_ACTION_IDS } from "@/lib/aiCoach/constants";
+import {
+  AI_COACH_QUICK_ACTION_IDS,
+  type AiCoachQuickActionId,
+} from "@/lib/aiCoach/constants";
 import styles from "./QuickActionButtons.module.css";
 
 interface QuickActionButtonsProps {
   disabled?: boolean;
-  onSelect: (prompt: string) => void;
+  // 分析（quick_action_id ブレイクダウン）のため id も併せて通知する
+  onSelect: (id: AiCoachQuickActionId, prompt: string) => void;
 }
 
 // 定型プロンプトのボタン群。文言・プロンプト本文は i18n（aiCoach.quickActions.*）から取得する。
@@ -24,7 +28,7 @@ export const QuickActionButtons: FC<QuickActionButtonsProps> = ({
           type="button"
           className={styles.action}
           disabled={disabled}
-          onClick={() => onSelect(t(`aiCoach.quickActions.${id}.prompt`))}
+          onClick={() => onSelect(id, t(`aiCoach.quickActions.${id}.prompt`))}
         >
           {t(`aiCoach.quickActions.${id}.label`)}
         </button>


### PR DESCRIPTION
## 概要

AIコーチ機能の **利用度・クイックアクション活用率** を Umami で分析できるよう、計測イベントを追加・拡張しました。

#281 でリリース済みの AI コーチについて、ユーザーが固定プロンプトボタン（「今週の振り返り」「苦手な技の分析」「自由技を提案」「上達のアドバイス」）をどれくらい活用しているか、ボタンの種類別人気はどうかを定量的に把握するのが目的です。

## 変更内容

### 新規イベント: \`ai_coach_quick_action_click\`
固定プロンプトボタンを押した瞬間（利用制限チェックの**前**）に発火。クリックの「意図」と「実際の送信完遂」を分離して計測できます。

| プロパティ | 値 |
|---|---|
| \`quick_action_id\` | \`weeklyReview\` / \`weakPoints\` / \`freeTechnique\` / \`improvementAdvice\` |
| \`source\` | \`landing\`（起動直後の画面） / \`in_chat\`（過去チャットを開いた状態） |

### 既存イベント拡張: \`ai_coach_message_send\`
\`quick_action_id\` プロパティを追加。フリー入力では \`null\`、クイックアクション経由では識別子が入ります。既存の \`is_quick_action: boolean\` は互換のため残しています。

### 既存トラッキング（変更なし、参考まで）
- \`ai_coach_chat_start\` — 起動ボタン押下時（\`FilterArea.tsx\`、\`source: \"page_list_filter\"\` 付き）
- \`ai_coach_limit_reached\` — 利用上限到達時

## 実装上のポイント

- \`QuickActionButtons\` の \`onSelect\` シグネチャを \`(prompt: string) => void\` → \`(id: AiCoachQuickActionId, prompt: string) => void\` へ拡張し、id を型安全に親へ伝播
- \`AiCoachChat\` 親で \`handleQuickActionClick(id, source)\` を提供。\`LandingView\` / \`ChatSession\` 双方の QuickActionButtons から呼ばれる（\`source\` で経路識別）
- \`handleBeforeSend\` のシグネチャを \`(charCount, isQuickAction)\` → \`(charCount, quickActionId | null)\` に変更し、message_send へ id を同梱

## これで見える分析指標

1. **AIコーチ全体の起動率** — \`ai_coach_chat_start\`（既存）
2. **クイックアクション活用率** — \`ai_coach_quick_action_click\` ÷ \`ai_coach_chat_start\`
3. **プロンプト別の人気** — \`quick_action_id\` 別の集計
4. **クリック→送信完遂率** — \`ai_coach_message_send\`(is_quick_action=true) ÷ \`ai_coach_quick_action_click\`
   - 差分は利用上限到達でドロップしたユーザー（\`ai_coach_limit_reached\` でクロス確認可能）
5. **landing vs in_chat** — どちらの状態でクイックアクションがよく使われるか

## 検証

- \`pnpm exec tsc --noEmit\` クリーン
- \`pnpm exec biome check\` 変更ファイルでクリーン
- フロントエンドユニットテスト 317件 すべて通過
- Umami の DOM スクリプトが読み込まれない環境では \`window.umami\` ガードで no-op になる既存挙動を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)