### PR TITLE
fix(ai-coach): キーボード展開時にヘッダーと過去チャットが画面外へ消える問題を修正

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/ai-coach/chat/page.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/personal/ai-coach/chat/page.tsx
@@ -1,4 +1,13 @@
+import type { Viewport } from "next";
 import { AiCoachChat } from "@/components/features/personal/AiCoach/AiCoachChat";
+
+// ソフトキーボード展開時にレイアウトビューポートを縮める。
+// 結果として 100dvh が「キーボード分を除いた可視高」と一致し、ヘッダーは固定、
+// composer のみがキーボードのすぐ上に押し上がる挙動になる（resizes-visual だと
+// ページ全体が上スクロールし、ヘッダーや過去チャットが画面外に消える）。
+export const viewport: Viewport = {
+  interactiveWidget: "resizes-content",
+};
 
 export default function AiCoachChatPage() {
   return <AiCoachChat />;

--- a/frontend/src/components/features/personal/AiCoach/AiCoachChat.module.css
+++ b/frontend/src/components/features/personal/AiCoach/AiCoachChat.module.css
@@ -1,23 +1,22 @@
 /*
  * AIコーチのチャットは PC でも全画面幅を使う特例レイアウト（他画面は 580px 中央寄せ）。
- * 共通レイアウトの max-width を取り消し、SP/PC ともに親要素いっぱいに広げる。
+ * SP/PC ともに親要素いっぱいに広げる。
+ *
+ * モバイルでソフトキーボードが開いたときの挙動制御:
+ *   - position: fixed + inset: 0 でページ自体をスクロール不能にする
+ *   - height: 100dvh は dynamic viewport height（キーボード分を除いた可視高）
+ *   - ページ側で viewport の interactive-widget=resizes-content を指定しているため、
+ *     キーボード展開時に dvh が縮み、ヘッダーは画面上端に残ったまま composer のみが
+ *     キーボード直上に押し上がる（resizes-visual のデフォルトだとページ全体が上に
+ *     スクロールし、ヘッダーや過去チャット一覧が画面外へ消えてしまう）
  */
 .layout {
+  position: fixed;
+  inset: 0;
   display: flex;
   flex-direction: column;
   height: 100dvh;
   background: var(--white);
-}
-
-/*
- * PWA standalone ではアドレスバーが無く 100dvh==100vh となり body スクロールで
- * フッター（入力欄）が画面外に隠れることがあるため、fixed で固定する。
- */
-@media all and (display-mode: standalone) {
-  .layout {
-    position: fixed;
-    inset: 0;
-  }
 }
 
 .header {


### PR DESCRIPTION
## 概要

AIコーチのチャット画面（`/personal/ai-coach/chat`）の landing 状態で textArea にフォーカスが当たり、モバイル端末のソフトキーボードが開いた瞬間に、**AIコーチのヘッダー（戻る／タイトル／＋ボタン）と過去チャット一覧が画面外へ消えてしまう** UX 上の不具合を修正します。

> ブラウザがフォーカス要素を可視域に収めようとしてページ全体を上にスクロールしているのが原因。期待挙動は「ヘッダーと過去チャットは固定、composer（クイックアクション + textArea）のみキーボード直上に押し上がる」。

## 修正内容

### 1. ページレベル viewport に `interactiveWidget: "resizes-content"` を指定
`frontend/src/app/[locale]/(authenticated)/personal/ai-coach/chat/page.tsx`

```ts
export const viewport: Viewport = {
  interactiveWidget: "resizes-content",
};
```

デフォルトの `resizes-visual` ではキーボード展開時に visual viewport のみ縮み、layout viewport は変わらず、結果としてブラウザが focused element を見せるためページをスクロールします。`resizes-content` を指定することで **layout viewport もキーボード分を除いた可視高に縮む** ようになり、`dvh` 単位の値がそれに追従します。

スコープは AIコーチのチャットページのみ。他画面の入力フォーム挙動には影響しません。

### 2. `.layout` を常時 `position: fixed; inset: 0;` に
従来は PWA standalone モードでのみ適用していましたが、通常ブラウザでも適用するよう変更。これにより **ページ自体がスクロール不能** になり、`height: 100dvh`（前項のおかげでキーボード分を除いた高さに自動追従）と組み合わせて、

- ヘッダーは画面上端に残ったまま
- composer はキーボード直上に押し上がる
- メッセージ領域（過去チャット）は中間で縮む

という挙動になります。

## ブラウザ対応

- `interactive-widget` メタ値: Chrome 108+（2022年）、Safari iOS 16.4+（2023年）
- 古いブラウザでは無視されてデフォルトの `resizes-visual` 挙動に戻りますが、PWA インストール時は元々 `position: fixed` の挙動で機能しています

## 検証

- `pnpm exec tsc --noEmit` クリーン
- `pnpm exec biome check` 変更ファイルでクリーン
- 実機での挙動確認をマージ後にお願いします（コードでの再現が難しい領域のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)