### PR TITLE
fix(ai-coach): iOS Safari / WKWebView でキーボード展開時もヘッダーを画面内に保持 (#321 follow-up)

### DIFF
--- a/frontend/src/components/features/personal/AiCoach/AiCoachChat.module.css
+++ b/frontend/src/components/features/personal/AiCoach/AiCoachChat.module.css
@@ -4,11 +4,12 @@
  *
  * モバイルでソフトキーボードが開いたときの挙動制御:
  *   - position: fixed + inset: 0 でページ自体をスクロール不能にする
- *   - height: 100dvh は dynamic viewport height（キーボード分を除いた可視高）
- *   - ページ側で viewport の interactive-widget=resizes-content を指定しているため、
- *     キーボード展開時に dvh が縮み、ヘッダーは画面上端に残ったまま composer のみが
- *     キーボード直上に押し上がる（resizes-visual のデフォルトだとページ全体が上に
- *     スクロールし、ヘッダーや過去チャット一覧が画面外へ消えてしまう）
+ *   - height: 100dvh は JS 非対応環境向けのフォールバック
+ *   - 実際の追従は AiCoachChat.tsx 側で visualViewport API を購読し、
+ *     インラインスタイルで .layout の top/height をキーボード除外後の
+ *     可視領域に合わせて書き換える方式（iOS Safari / WKWebView は
+ *     viewport の interactive-widget=resizes-content を未サポートのため、
+ *     CSS だけだとヘッダーや過去チャット一覧が画面外へ消えてしまう）
  */
 .layout {
   position: fixed;

--- a/frontend/src/components/features/personal/AiCoach/AiCoachChat.tsx
+++ b/frontend/src/components/features/personal/AiCoach/AiCoachChat.tsx
@@ -306,6 +306,37 @@ export function AiCoachChat() {
   const [showPremiumModal, setShowPremiumModal] = useState(false);
   const [showDeleteAllConfirm, setShowDeleteAllConfirm] = useState(false);
   const [isCreatingFromLanding, setIsCreatingFromLanding] = useState(false);
+  const layoutRef = useRef<HTMLDivElement>(null);
+
+  // iOS Safari / WKWebView は viewport の interactive-widget=resizes-content をサポートしておらず、
+  // キーボード展開時に layout viewport は full height のまま visual viewport だけ縮む。
+  // 結果として position: fixed + inset:0 のレイアウト上端（ヘッダー）が画面外へ押し出されてしまうので、
+  // visualViewport API でキーボード除外後の可視領域に追従させ、ヘッダー・過去チャット一覧を画面内に保持する。
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const updateLayout = () => {
+      const el = layoutRef.current;
+      if (!el) return;
+      el.style.top = `${vv.offsetTop}px`;
+      el.style.height = `${vv.height}px`;
+    };
+
+    updateLayout();
+    vv.addEventListener("resize", updateLayout);
+    vv.addEventListener("scroll", updateLayout);
+
+    return () => {
+      vv.removeEventListener("resize", updateLayout);
+      vv.removeEventListener("scroll", updateLayout);
+      const el = layoutRef.current;
+      if (el) {
+        el.style.top = "";
+        el.style.height = "";
+      }
+    };
+  }, []);
 
   // 初期化: 会話一覧の取得のみ（自動オープンしない＝常に landing から開始）
   useEffect(() => {
@@ -449,7 +480,7 @@ export function AiCoachChat() {
   );
 
   return (
-    <div className={styles.layout}>
+    <div ref={layoutRef} className={styles.layout}>
       <header className={styles.header}>
         <button
           type="button"


### PR DESCRIPTION
## Summary

#321 で \`interactiveWidget: "resizes-content"\` + \`100dvh\` の CSS フォールバックを入れたが、これは Chromium 系のみ対応で、iOS Safari / iOS 版アプリの WKWebView ではブラウザがフォーカス要素を可視域に収めるためにページ全体を上スクロールしてしまい、結果としてヘッダー（戻る / タイトル / ＋）や過去チャット一覧が画面外に押し出される挙動が残っていた。

## 修正内容

\`AiCoachChat\` 側で \`visualViewport\` API を購読し、\`.layout\` の \`top\` / \`height\` をキーボード除外後の可視領域にインラインで追従させる JS 制御を追加。

- **Chromium**: \`interactiveWidget\` による layout viewport 縮小と整合し、JS は \`top: 0\` / \`height: 縮小後 dvh\` を当てるだけ
- **Safari / WKWebView**: \`visualViewport.offsetTop\` / \`height\` を直接トラックして同じ挙動を得る

未対応ブラウザは \`if (!vv) return;\` で早期 return し、従来の \`100dvh\` フォールバックがそのまま効く。

## 変更ファイル

- \`AiCoachChat.tsx\`: \`useEffect\` で \`window.visualViewport\` の \`resize\` / \`scroll\` を購読し \`layoutRef\` に \`top\` / \`height\` をインラインで反映。アンマウント時にインラインスタイル除去
- \`AiCoachChat.module.css\`: コメントを「CSS 単独ではなく JS による visualViewport 追従」に修正

## 既存ユーザーへの影響

- 触る範囲は \`/personal/ai-coach/chat\` の 1 ページのみ
- \`visualViewport\` API は Chrome 61+ / Safari 13+ / Firefox 91+ で広く対応済み
- 未対応環境は既存挙動のまま
- DB / API への変更なし → デプロイ順序の制約なし、単独で main マージ可

## Test plan

- [x] frontend typecheck
- [x] frontend test 317/317 pass
- [x] frontend biome check (warning 6 件は pre-existing)
- [ ] iOS Safari 実機で \`/personal/ai-coach/chat\` を開き、textArea にフォーカスしてヘッダーと過去チャットが画面内に残ることを確認
- [ ] iOS 版アプリ (TestFlight) の WebView 経由でも同様に確認
- [ ] Android Chrome でも従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)