### PR TITLE
fix: iOS で入力欄フォーカス時の自動ズームを解消（#327）

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/personal/calendar/CalendarFooter.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/personal/calendar/CalendarFooter.module.css
@@ -109,7 +109,7 @@
   border-radius: 6px;
   text-align: center;
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   background: var(--white);
 }
@@ -170,7 +170,7 @@
   border-radius: 6px;
   padding: 0 8px;
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   background: var(--white);
 }

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/edit/PageEdit.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/[page_id]/edit/PageEdit.module.css
@@ -78,7 +78,7 @@
   padding: 8px 10px;
   border: 0.5px solid var(--border-color);
   border-radius: 4px;
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   font-family: var(--font-ui);
   background: var(--white);
   color: var(--black);

--- a/frontend/src/app/[locale]/(authenticated)/personal/pages/new/PageCreate.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/personal/pages/new/PageCreate.module.css
@@ -114,7 +114,7 @@
   padding: 8px 10px;
   border: 0.5px solid var(--border-color);
   border-radius: 4px;
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   font-family: var(--font-ui);
   background: var(--white);
   color: var(--black);

--- a/frontend/src/app/[locale]/(authenticated)/settings/tags/TagManagement.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/settings/tags/TagManagement.module.css
@@ -102,7 +102,7 @@
   padding: 8px 10px;
   border: 0.5px solid var(--border-color);
   border-radius: 4px;
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   font-family: var(--font-ui);
   background: var(--white);
   color: var(--black);
@@ -172,7 +172,7 @@
   padding: 6px 10px;
   border: 0.5px solid var(--border-color);
   border-radius: 4px;
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   font-family: var(--font-ui);
   background: var(--white);
   color: var(--black);
@@ -206,7 +206,7 @@
   padding: 8px 10px;
   border: 0.5px solid var(--border-color);
   border-radius: 4px;
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   font-family: var(--font-ui);
   background: var(--white);
   color: var(--black);

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/[post_id]/edit/SocialPostEdit.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/[post_id]/edit/SocialPostEdit.module.css
@@ -26,7 +26,7 @@
   min-height: 200px;
   padding: 12px;
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/frontend/src/app/[locale]/(authenticated)/social/posts/new/SocialPostCreate.module.css
+++ b/frontend/src/app/[locale]/(authenticated)/social/posts/new/SocialPostCreate.module.css
@@ -131,7 +131,7 @@
   min-height: 200px;
   padding: 12px;
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -200,7 +200,7 @@
   padding: 8px 10px;
   border: 0.5px solid var(--border-color);
   border-radius: 4px;
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   font-family: var(--font-ui);
   background: var(--white);
   color: var(--black);

--- a/frontend/src/app/[locale]/(public)/login/page.module.css
+++ b/frontend/src/app/[locale]/(public)/login/page.module.css
@@ -245,7 +245,7 @@
   border-radius: 4px;
   padding: 6px 12px;
   font-family: var(--font-ui);
-  font-size: 14px;
+  font-size: var(--input-font-size);
   color: var(--black);
   outline: none;
   transition: border-color 0.4s ease-out;

--- a/frontend/src/app/[locale]/(public)/signup/page.module.css
+++ b/frontend/src/app/[locale]/(public)/signup/page.module.css
@@ -343,7 +343,7 @@
   border-radius: 4px;
   padding: 6px 12px;
   font-family: var(--font-ui);
-  font-size: 14px;
+  font-size: var(--input-font-size);
   color: var(--black);
   outline: none;
   transition: border-color 0.4s ease-out;

--- a/frontend/src/components/features/auth/ForgotPasswordForm/ForgotPasswordForm.module.css
+++ b/frontend/src/components/features/auth/ForgotPasswordForm/ForgotPasswordForm.module.css
@@ -79,7 +79,7 @@
   border-radius: 4px;
   padding: 6px 12px;
   font-family: var(--font-ui);
-  font-size: 14px;
+  font-size: var(--input-font-size);
   color: var(--black);
   outline: none;
   transition: border-color 0.4s ease-out;

--- a/frontend/src/components/features/auth/ResetPasswordForm/ResetPasswordForm.module.css
+++ b/frontend/src/components/features/auth/ResetPasswordForm/ResetPasswordForm.module.css
@@ -83,7 +83,7 @@
   border-radius: 4px;
   padding: 6px 12px;
   font-family: var(--font-ui);
-  font-size: 14px;
+  font-size: var(--input-font-size);
   color: var(--black);
   outline: none;
   transition: border-color 0.4s ease-out;

--- a/frontend/src/components/features/personal/AiCoach/AiCoachChat.module.css
+++ b/frontend/src/components/features/personal/AiCoach/AiCoachChat.module.css
@@ -172,7 +172,7 @@
   border: 0.5px solid var(--border-color);
   border-radius: 18px;
   font-family: var(--font-ui);
-  font-size: var(--font-size-base);
+  font-size: var(--input-font-size);
   background: var(--white);
   color: var(--black);
   outline: none;

--- a/frontend/src/components/features/personal/AttachmentUpload/AttachmentUpload.module.css
+++ b/frontend/src/components/features/personal/AttachmentUpload/AttachmentUpload.module.css
@@ -72,7 +72,7 @@
   padding: 6px 10px;
   border: 1px solid var(--border-color);
   border-radius: 6px;
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   font-family: var(--font-ui);
   height: 32px;
 }

--- a/frontend/src/components/features/personal/DatePickerModal/DatePickerModal.module.css
+++ b/frontend/src/components/features/personal/DatePickerModal/DatePickerModal.module.css
@@ -97,7 +97,7 @@
   border: 1px solid #e1e1e1;
   border-radius: 12px;
   padding: 8px 10px;
-  font-size: 0.95rem;
+  font-size: var(--input-font-size);
   background: #fff;
 }
 

--- a/frontend/src/components/features/social/ReportModal/ReportModal.module.css
+++ b/frontend/src/components/features/social/ReportModal/ReportModal.module.css
@@ -65,7 +65,7 @@
   min-height: 80px;
   padding: 10px;
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/frontend/src/components/features/social/SocialReplyForm/SocialReplyForm.module.css
+++ b/frontend/src/components/features/social/SocialReplyForm/SocialReplyForm.module.css
@@ -15,7 +15,7 @@
   flex: 1;
   padding: 10px 12px;
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   border: 1px solid var(--border-color);
   border-radius: 20px;

--- a/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.module.css
+++ b/frontend/src/components/features/social/SocialReplyItem/SocialReplyItem.module.css
@@ -149,7 +149,7 @@
   min-height: 60px;
   padding: 8px;
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/frontend/src/components/shared/DateRangeInput/DateRangeInput.module.css
+++ b/frontend/src/components/shared/DateRangeInput/DateRangeInput.module.css
@@ -20,7 +20,7 @@
 
 .input {
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/frontend/src/components/shared/DojoStyleAutocomplete/DojoStyleAutocomplete.module.css
+++ b/frontend/src/components/shared/DojoStyleAutocomplete/DojoStyleAutocomplete.module.css
@@ -6,7 +6,7 @@
 .input {
   width: 100%;
   font-family: var(--font-ui);
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   line-height: 1.45;
   padding: 10px 14px;
   border: 0.5px solid var(--border-color);

--- a/frontend/src/components/shared/SearchInput/SearchInput.module.css
+++ b/frontend/src/components/shared/SearchInput/SearchInput.module.css
@@ -22,7 +22,7 @@
   border-radius: 6px;
   background: var(--white);
   font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
+  font-size: var(--input-font-size);
   color: var(--black);
   outline: none;
   transition: border-color 0.4s ease-out;

--- a/frontend/src/components/shared/SelectInput/SelectInput.module.css
+++ b/frontend/src/components/shared/SelectInput/SelectInput.module.css
@@ -24,7 +24,7 @@
 
 .select {
   font-family: var(--font-ui);
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   line-height: 1.45;
   padding: 10px 32px 10px 14px;
   border: 0.5px solid var(--border-color);

--- a/frontend/src/components/shared/TextArea/TextArea.module.css
+++ b/frontend/src/components/shared/TextArea/TextArea.module.css
@@ -24,7 +24,7 @@
 
 .textarea {
   font-family: var(--font-ui);
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   line-height: 1.6;
   padding: 10px 14px;
   border: 0.5px solid var(--border-color);

--- a/frontend/src/components/shared/TextInput/TextInput.module.css
+++ b/frontend/src/components/shared/TextInput/TextInput.module.css
@@ -24,7 +24,7 @@
 
 .input {
   font-family: var(--font-ui);
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   line-height: 1.45;
   padding: 10px 14px;
   border: 0.5px solid var(--border-color);

--- a/frontend/src/components/shared/TitleTemplateModal/TitleTemplateModal.module.css
+++ b/frontend/src/components/shared/TitleTemplateModal/TitleTemplateModal.module.css
@@ -161,7 +161,7 @@
 
 .select {
   font-family: var(--font-ui);
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   padding: 8px 10px;
   border: 0.5px solid var(--border-color);
   border-radius: 4px;
@@ -177,7 +177,7 @@
 
 .textInput {
   font-family: var(--font-ui);
-  font-size: var(--font-size-xs);
+  font-size: var(--input-font-size);
   padding: 8px 10px;
   border: 0.5px solid var(--border-color);
   border-radius: 4px;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -59,6 +59,15 @@ select {
   letter-spacing: inherit;
 }
 
+/* iOS WebKit のフォーカス時自動ズーム防止：入力要素の computed font-size を
+   最小 16px に底上げする（className 未指定・今後追加される入力欄のデフォルト）。
+   既存の各 CSS Module はクラスセレクタで詳細度が上のため、各所も var(--input-font-size) に揃える。 */
+input,
+textarea,
+select {
+  font-size: var(--input-font-size);
+}
+
 /* 7. Avoid text overflows */
 p,
 h1,

--- a/frontend/src/styles/variables.css
+++ b/frontend/src/styles/variables.css
@@ -112,6 +112,11 @@
   --font-size-xl: calc(var(--current-font-size) * 1.25);
   --font-size-2xl: calc(var(--current-font-size) * 1.5);
   --font-size-3xl: calc(var(--current-font-size) * 1.875);
+
+  /* 入力要素専用フォントサイズ。iOS WebKit は input/textarea/select の computed
+     font-size が 16px 未満だとフォーカス時に自動ズームするため、最小 16px を保証する。
+     large 設定時は 20px まで拡大し、フォントサイズ設定（拡大）の意図を維持する。 */
+  --input-font-size: max(16px, var(--font-size-base));
 }
 
 /* フォントサイズ切り替え用のデータ属性 */


### PR DESCRIPTION
## 概要
iOS アプリ（Expo WebView）/ iOS Safari で、入力欄にフォーカスするとビューポートが自動ズームし、blur 後も戻らない不具合（#327）を解消します。

## 原因
iOS WebKit は `input` / `textarea` / `select` の computed `font-size` が **16px 未満**だとフォーカス時に自動ズームします（WebView 固有ではなく iOS Safari でも発生）。AikiNote はフォントサイズ設定（small/medium/large）に応じた相対トークンで入力欄サイズを決めており、**既定の medium 設定でも大半の入力欄が 16px 未満**でした:

- TextInput / SelectInput / TextArea 等 … `--font-size-xs`（medium で 12px）
- SearchInput / DateRangeInput 等 … `--font-size-sm`（medium で 14px）
- 認証フォーム（Login / SignUp / ForgotPassword / ResetPassword）… `14px` ハードコード
- DatePickerModal … `0.95rem`（≈15.2px）

## 変更内容
- `variables.css`: 入力欄専用変数 `--input-font-size: max(16px, var(--font-size-base))` を新設（small/medium=16px、large=20px）
- 全入力欄の `font-size` をこの変数に統一（共通コンポーネント5件 + 個別CSS + ハードコード箇所、計 23 CSS Module）
- `globals.css`: `input, textarea, select` の `font-size` 底上げを追加（className 未指定・今後追加される入力欄の再発防止）
- viewport は変更せず（ピンチズーム=高齢者アクセシビリティを維持）、`transform: scale()` も不使用

自動ズームを解消しつつ、フォントサイズ拡大設定（large=20px）は維持されます。入力欄の文字は現状 medium で 12〜14px → 16px に大きくなります。

## 検証
- `pnpm check`（Biome）/ `pnpm test`（frontend 44ファイル333テスト・backend 23ファイル230テスト）/ `pnpm build` パス済み
- **要 iOS 実機 / Simulator 確認**（macOS Safari・Chrome DevTools では再現しない WebKit 仕様のため）:
  - 各入力欄をタップ → ズームしないこと、blur 後に表示が崩れないこと
  - フォントサイズ設定 **small / medium / large** の3パターンで確認
  - 回帰: ログイン / サインアップ / パスワード再設定、稽古ノート作成・編集、道場/タグ検索、各種フォームモーダル（TitleTemplate / DatePicker / AttachmentUpload）、投稿作成・返信、AIコーチ、タグ管理
  - 特に Login / SignUp の `.inputField`（`height: 36px`）で行が窮屈にならないか目視（崩れる場合のみ `line-height` 微調整）

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)