### PR TITLE
chore: 認証初期化を2段階化しデータ取得ウォーターフォールを解消

### DIFF
--- a/frontend/src/components/features/social/SocialFeedHeader/SocialFeedHeader.tsx
+++ b/frontend/src/components/features/social/SocialFeedHeader/SocialFeedHeader.tsx
@@ -62,13 +62,20 @@ export const SocialFeedHeader: FC = () => {
 
   return (
     <SocialHeader>
-      <Link
-        href={`/social/profile/${user?.username ?? ""}`}
-        className={styles.profileLink}
-        aria-label={t("profile")}
-      >
-        <ProfileImage src={profileImageUrl} size="small" />
-      </Link>
+      {user?.username ? (
+        <Link
+          href={`/social/profile/${user.username}`}
+          className={styles.profileLink}
+          aria-label={t("profile")}
+        >
+          <ProfileImage src={profileImageUrl} size="small" />
+        </Link>
+      ) : (
+        // username 未取得（プロフィール読み込み中）の間はリンクにしない
+        <span className={styles.profileLink}>
+          <ProfileImage src={profileImageUrl} size="small" />
+        </span>
+      )}
       <h1 className={styles.title}>{t("title")}</h1>
       <div className={styles.rightActions}>
         <nav className={styles.desktopNav}>

--- a/frontend/src/lib/hooks/useAuth.test.tsx
+++ b/frontend/src/lib/hooks/useAuth.test.tsx
@@ -83,7 +83,8 @@ describe("useAuth hook - セッション監視機能", () => {
     );
   });
 
-  it("認証状態変更中にエラーが発生した場合の処理", async () => {
+  it("認証状態変更中にプロフィール取得が失敗しても暫定ユーザーで継続する", async () => {
+    // Arrange
     (userApi.fetchUserProfile as Mock).mockRejectedValue(
       new Error("ネットワークエラー"),
     );
@@ -96,16 +97,21 @@ describe("useAuth hook - セッション監視機能", () => {
 
     const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
 
-    // 認証状態変更をシミュレート（エラーケース）
+    await waitFor(() => {
+      expect(result.current.isInitializing).toBe(false);
+    });
+
+    // Act: 認証状態変更をシミュレート（プロフィール取得はエラー）
     await act(async () => {
       authStateChangeCallback("SIGNED_IN", {
         user: { id: "user-123", email: "test@example.com" },
       });
     });
 
+    // Assert: セッション由来の暫定ユーザーは維持され、エラー状態にもならない
     await waitFor(() => {
-      expect(result.current.user).toBeNull();
-      expect(result.current.error).toBeNull(); // ネットワークエラーはエラー状態に設定されない
+      expect(result.current.user?.id).toBe("user-123");
+      expect(result.current.error).toBeNull();
     });
   });
 
@@ -221,7 +227,8 @@ describe("useAuth hook - ユーザー取得ロジック統一", () => {
     });
   });
 
-  it("ユーザープロフィール取得失敗時の処理", async () => {
+  it("ユーザープロフィール取得失敗時はセッション由来の暫定ユーザーを維持する", async () => {
+    // Arrange
     (userApi.fetchUserProfile as Mock).mockResolvedValue(null);
 
     mockSupabaseClient.auth.getSession.mockResolvedValue({
@@ -233,14 +240,21 @@ describe("useAuth hook - ユーザー取得ロジック統一", () => {
       error: null,
     });
 
+    // Act
     const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
 
-    await waitFor(
-      () => {
-        expect(result.current.user).toBeNull();
-      },
-      { timeout: 2000 },
-    );
+    // Assert: 暫定ユーザーが即時セットされる
+    await waitFor(() => {
+      expect(result.current.user?.id).toBe("user-123");
+    });
+
+    // Act: 全リトライ（200ms × 2回）が失敗するまで待つ
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 700));
+    });
+
+    // Assert: 失敗後も null に戻らず暫定ユーザーのまま継続する
+    expect(result.current.user?.id).toBe("user-123");
   });
 
   it("ユーザープロフィール取得が遅延してもリトライで成功する", async () => {
@@ -270,6 +284,102 @@ describe("useAuth hook - ユーザー取得ロジック統一", () => {
       await new Promise((resolve) => setTimeout(resolve, 700));
     });
 
+    expect(result.current.user).toEqual(mockUser);
+  });
+
+  it("プロフィール取得の完了を待たずに暫定ユーザーで初期化が完了する", async () => {
+    // Arrange: プロフィール取得は解決させずに保留したままにする
+    let resolveProfile: (value: unknown) => void = () => {};
+    (userApi.fetchUserProfile as Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveProfile = resolve;
+        }),
+    );
+
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: {
+        session: {
+          user: {
+            id: "user-123",
+            email: "test@example.com",
+            user_metadata: { username: "session-user" },
+          },
+        },
+      },
+      error: null,
+    });
+
+    mockSupabaseClient.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+
+    // Act
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+
+    // Assert: プロフィール API が未解決でも user.id が確定し、初期化が完了している
+    await waitFor(() => {
+      expect(result.current.isInitializing).toBe(false);
+      expect(result.current.user?.id).toBe("user-123");
+      expect(result.current.user?.username).toBe("session-user");
+    });
+
+    // Act: 裏で取得していたフルプロフィールが到着する
+    const fullProfile = {
+      id: "user-123",
+      email: "test@example.com",
+      username: "full-user",
+      profile_image_url: "https://example.com/avatar.png",
+    };
+    await act(async () => {
+      resolveProfile(fullProfile);
+    });
+
+    // Assert: フルプロフィールへ置き換わる
+    await waitFor(() => {
+      expect(result.current.user).toEqual(fullProfile);
+    });
+  });
+
+  it("同一ユーザーのトークンリフレッシュでは再初期化もプロフィール再取得もしない", async () => {
+    // Arrange
+    const mockUser = {
+      id: "user-123",
+      email: "test@example.com",
+      username: "testuser",
+      profile_image_url: null,
+    };
+    (userApi.fetchUserProfile as Mock).mockResolvedValue(mockUser);
+
+    const session = {
+      user: { id: "user-123", email: "test@example.com" },
+    };
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session },
+      error: null,
+    });
+
+    let authStateChangeCallback: AuthStateChangeHandler = () => {};
+    mockSupabaseClient.auth.onAuthStateChange.mockImplementation((callback) => {
+      authStateChangeCallback = callback;
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.user).toEqual(mockUser);
+    });
+    (userApi.fetchUserProfile as Mock).mockClear();
+
+    // Act: 同一ユーザーのままトークンリフレッシュが発生
+    await act(async () => {
+      authStateChangeCallback("TOKEN_REFRESHED", session);
+    });
+
+    // Assert: 再初期化もプロフィール再取得も行われない
+    expect(userApi.fetchUserProfile).not.toHaveBeenCalled();
+    expect(result.current.isInitializing).toBe(false);
     expect(result.current.user).toEqual(mockUser);
   });
 });

--- a/frontend/src/lib/hooks/useAuth.tsx
+++ b/frontend/src/lib/hooks/useAuth.tsx
@@ -74,12 +74,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isInitializingRef = useRef(true);
+  const currentUserIdRef = useRef<string | null>(null);
   const router = useRouter();
   const locale = useLocale();
   const t = useTranslations("auth");
   const { showToast } = useToast();
   const supabase = useMemo(() => {
     return getClientSupabase();
+  }, []);
+
+  // setUser と currentUserIdRef を常に同期させるためのラッパー。
+  // ref は onAuthStateChange の同一ユーザー判定と、
+  // 裏で走るプロフィール取得の「取得中にユーザーが変わっていないか」判定に使う。
+  const applyUser = useCallback((nextUser: UserSession | null) => {
+    currentUserIdRef.current = nextUser?.id ?? null;
+    setUser(nextUser);
   }, []);
 
   useEffect(() => {
@@ -117,21 +126,58 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return null;
     };
 
-    const applySession = async (session: Session | null) => {
+    // セッションのユーザー情報から即時利用できる暫定プロフィールを組み立てる。
+    // getUserInfo API の往復を待たずに user.id を確定させ、
+    // 各画面のデータ取得（enabled: !!user?.id）を先に発火させるための1段階目。
+    const buildProvisionalUser = (
+      sessionUser: Session["user"],
+    ): UserSession => {
+      const metadata = (sessionUser.user_metadata ?? {}) as {
+        username?: string;
+        avatar_url?: string;
+      };
+      return {
+        id: sessionUser.id,
+        email: sessionUser.email ?? "",
+        username: metadata.username ?? "",
+        profile_image_url: metadata.avatar_url ?? null,
+        dojo_style_name: null,
+        aikido_rank: null,
+        full_name: null,
+      };
+    };
+
+    const applySession = (session: Session | null) => {
       if (!isMounted) return;
 
-      if (session?.user) {
-        const userProfile = await fetchUserProfileWithRetry(session.user.id);
-
-        if (userProfile && isMounted) {
-          setUser(userProfile);
-          return;
-        }
+      if (!session?.user) {
+        applyUser(null);
+        return;
       }
 
-      if (isMounted) {
-        setUser(null);
-      }
+      const sessionUserId = session.user.id;
+      applyUser(buildProvisionalUser(session.user));
+
+      // 2段階目: フルプロフィールは裏で取得し、到着次第置き換える
+      void fetchUserProfileWithRetry(sessionUserId)
+        .then((profile) => {
+          if (!isMounted) return;
+          // 取得中にサインアウトやユーザー切替が起きていたら反映しない
+          if (currentUserIdRef.current !== sessionUserId) return;
+          if (profile) {
+            applyUser(profile);
+          } else {
+            // 全リトライ失敗でも暫定ユーザーを維持する。null に戻すと発火済みの
+            // クエリが一斉に無効化されて画面がちらつくため
+            // （未認証からのページ保護はサーバー側の AuthGate が担っている）
+            console.error(
+              "useAuth: プロフィール取得に失敗しました。セッション情報で継続します",
+            );
+          }
+        })
+        .catch((profileError) => {
+          console.error("useAuth: プロフィール取得中にエラー:", profileError);
+        });
     };
 
     const initializeSession = async () => {
@@ -158,17 +204,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         if (error) {
           console.error("セッション取得エラー:", error);
-          setUser(null);
+          applyUser(null);
           return;
         }
 
         if (isMounted) {
-          await applySession(session);
+          // applySession は暫定ユーザーのセットまでを同期的に行うため、
+          // プロフィール API の往復を待たずに初期化を完了できる
+          applySession(session);
         }
       } catch (error) {
         console.error("セッション初期化中に予期せぬエラー:", error);
         if (isMounted) {
-          setUser(null);
+          applyUser(null);
         }
       } finally {
         if (isMounted) {
@@ -183,31 +231,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // セッション変更の監視を有効化（改善されたエラーハンドリング付き）
     const {
       data: { subscription },
-    } = supabaseClient.auth.onAuthStateChange(async (_event, session) => {
+    } = supabaseClient.auth.onAuthStateChange((_event, session) => {
       // 初期化中でない場合のみ処理
-      if (!isInitializingRef.current && isMounted) {
-        isInitializingRef.current = true;
-        setIsInitializing(true);
-        try {
-          await applySession(session);
-        } catch (error) {
-          console.error("認証状態変更処理中にエラー:", error);
-          if (isMounted) {
-            setUser(null);
-            // ネットワークエラー以外の場合はエラー状態を設定
-            if (
-              error instanceof Error &&
-              !error.message.includes("ネットワーク")
-            ) {
-              setError("認証状態の更新中にエラーが発生しました");
-            }
-          }
-        } finally {
-          if (isMounted) {
-            isInitializingRef.current = false;
-            setIsInitializing(false);
-          }
+      if (isInitializingRef.current || !isMounted) return;
+
+      // 同一ユーザーのままのイベント（約50分毎の TOKEN_REFRESHED 等）では
+      // 状態を再構築しない。以前は毎回 isInitializing=true → プロフィール再取得が
+      // 走り、全画面のクエリ停止と表示のちらつきが発生していた
+      if (session?.user?.id && session.user.id === currentUserIdRef.current) {
+        return;
+      }
+
+      isInitializingRef.current = true;
+      setIsInitializing(true);
+      try {
+        applySession(session);
+      } catch (error) {
+        console.error("認証状態変更処理中にエラー:", error);
+        applyUser(null);
+        // ネットワークエラー以外の場合はエラー状態を設定
+        if (error instanceof Error && !error.message.includes("ネットワーク")) {
+          setError("認証状態の更新中にエラーが発生しました");
         }
+      } finally {
+        isInitializingRef.current = false;
+        setIsInitializing(false);
       }
     });
 
@@ -215,7 +263,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isMounted = false;
       subscription.unsubscribe();
     };
-  }, [supabase]);
+  }, [supabase, applyUser]);
 
   // ネイティブアプリにユーザー情報を通知（認証状態変化時）。
   // ネイティブ側は受信した access_token を supabase.auth.setSession に渡し、
@@ -459,7 +507,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       // エラーがあってもなくても、ローカル状態をクリアしてリダイレクト
-      setUser(null);
+      applyUser(null);
 
       // PC幅・SP幅に応じて適切に表示されるように Toast にスタイルを渡す
       const isWide = window.matchMedia("(min-width: 431px)").matches;
@@ -479,7 +527,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         err,
       );
       // エラーが発生してもユーザー状態をクリアしてリダイレクト
-      setUser(null);
+      applyUser(null);
       const isWide = window.matchMedia("(min-width: 431px)").matches;
       const toastStyle: React.CSSProperties = isWide
         ? {}
@@ -500,7 +548,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsProcessing(false);
     }
-  }, [supabase.auth, router, showToast, t]);
+  }, [supabase.auth, router, showToast, t, applyUser]);
 
   const forgotPassword = useCallback(async (data: ResetPasswordFormData) => {
     setIsProcessing(true);
@@ -583,18 +631,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const userProfile = await fetchUserProfile(session.user.id);
 
         if (userProfile) {
-          setUser(userProfile);
+          applyUser(userProfile);
           return userProfile;
         }
       }
 
-      setUser(null);
+      applyUser(null);
       return null;
     } catch (error) {
       console.error("refreshUser: ユーザー情報の再取得エラー:", error);
       return null;
     }
-  }, [supabase.auth]);
+  }, [supabase.auth, applyUser]);
 
   const verifyEmail = useCallback(
     async (token: string) => {
@@ -631,7 +679,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
           await refreshUser();
         } else if (responseUser) {
-          setUser(responseUser);
+          applyUser(responseUser);
         }
 
         return result;
@@ -644,7 +692,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setIsProcessing(false);
       }
     },
-    [supabase.auth, refreshUser],
+    [supabase.auth, refreshUser, applyUser],
   );
 
   const clearError = useCallback(() => setError(null), []);


### PR DESCRIPTION
## 変更概要

認証済みページの「開いてからデータが表示されるまで」を短縮するパフォーマンス改善です。

これまで全認証ページで以下の**直列ウォーターフォール**が発生していました：

```
getSession()（セッション取得）
  → getUserInfo API（プロフィール取得、失敗時 200ms×2 リトライ）
    → ここでやっと isInitializing=false
      → 各画面のデータ取得クエリが発火（enabled: !authLoading && !!user?.id）
        → 表示
```

本 PR では初期化を2段階に分離します：

1. **1段階目（即時）**: `getSession()` 解決直後にセッション情報（`session.user`）から暫定 UserSession を構築して `setUser` し、`isInitializing` を解除。データ取得クエリはこの時点で発火する
2. **2段階目（裏で実行）**: フルプロフィール（`getUserInfo`）は await せずに取得し、到着次第置き換える

## 変更内容

- `useAuth.tsx`
  - `applySession` を同期化し、暫定ユーザー即時セット + プロフィール裏取得に変更
  - プロフィール取得の全リトライ失敗時は暫定ユーザーを維持（null に戻すと発火済みクエリが一斉無効化され画面がちらつくため。未認証からのページ保護はサーバー側 AuthGate が担当）
  - `onAuthStateChange` に同一ユーザー判定を追加。**約50分毎の TOKEN_REFRESHED のたびに全画面が isInitializing に戻ってプロフィール再取得が走る既存の無駄（ちらつき）も解消**
  - プロフィール取得中のサインアウト/ユーザー切替に対するガード（`currentUserIdRef`）を追加
- `SocialFeedHeader.tsx`
  - OAuth ユーザーはプロフィール到着まで `username` が空になるため、その間はプロフィールリンクを無効化

## 影響範囲

- 全認証済みページの初期表示（personal/pages, social/posts, カレンダー, 統計, 設定系など）
- 再訪時は React Query の localStorage 永続キャッシュ（user.id キー）が即座に一致するため、**保存済みデータが即描画→裏で最新化**という体感になる
- 公開ページ（ソーシャル投稿詳細の共有リンク等）も `isInitializing` の解除が早まるため表示が前倒しされる
- `user` オブジェクトの id 以外のフィールドを useAuth 経由で使うのは EmailSetting（email はセッションに含まれる）/ SocialFeedHeader（本 PR でガード追加）/ useUmamiTrack（null 許容）のみで、暫定ユーザーによる表示退行がないことを確認済み。ProfileEdit / MyPageContent はサーバー props 経由のため影響なし

## テスト

- `useAuth.test.tsx` を新挙動に合わせて更新 + 新規2ケース追加
  - プロフィール取得の完了を待たずに暫定ユーザーで初期化が完了する
  - 同一ユーザーのトークンリフレッシュでは再初期化もプロフィール再取得もしない
- `pnpm check` / `pnpm test`（335件）/ `pnpm build` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qYWDDj3HCuMfEHXv5jqkt