### PR TITLE
chore: tRPC 認証を getClaims ローカル検証化しリクエスト内でメモ化

### DIFF
--- a/frontend/src/app/api/trpc/[trpc]/route.ts
+++ b/frontend/src/app/api/trpc/[trpc]/route.ts
@@ -1,15 +1,14 @@
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { createTRPCContext } from "@/server/trpc";
 import { appRouter } from "@/server/trpc/router";
 
 // pages router の `pages/api/trpc/[trpc].ts` に相当する App Router 版ハンドラ
-const createContext = (req: Request) => ({ req });
-
 const handler = (req: Request) =>
   fetchRequestHandler({
     endpoint: "/api/trpc",
     req,
     router: appRouter,
-    createContext: () => createContext(req),
+    createContext: () => createTRPCContext(req),
     onError({ error, path }) {
       console.error(`[tRPC] path=${path ?? "unknown"}`, error); // TODO: 本格的にユーザーを集めるフェーズに入ったら消しておく
     },

--- a/frontend/src/lib/server/auth.test.ts
+++ b/frontend/src/lib/server/auth.test.ts
@@ -1,0 +1,148 @@
+/**
+ * getVerifiedAuthUser / createBackendAuthToken のテスト
+ * getClaims によるローカル検証と getUser フォールバックの分岐を検証する
+ */
+import jwt from "jsonwebtoken";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBackendAuthToken, getVerifiedAuthUser } from "./auth";
+
+const mockGetClaims = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  getServerSupabase: async () => ({
+    auth: {
+      getClaims: mockGetClaims,
+      getUser: mockGetUser,
+    },
+  }),
+}));
+
+vi.mock("@/lib/server/cache", () => ({
+  getCachedUserInfo: vi.fn(),
+}));
+
+describe("getVerifiedAuthUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getClaims が成功した場合、claims からユーザーを返し getUser は呼ばれない", async () => {
+    // Arrange
+    mockGetClaims.mockResolvedValue({
+      data: { claims: { sub: "user-123", email: "test@example.com" } },
+      error: null,
+    });
+
+    // Act
+    const user = await getVerifiedAuthUser();
+
+    // Assert
+    expect(user).toEqual({ id: "user-123", email: "test@example.com" });
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("getClaims がエラーの場合、getUser にフォールバックしてユーザーを返す", async () => {
+    // Arrange
+    mockGetClaims.mockResolvedValue({
+      data: null,
+      error: new Error("jwks fetch failed"),
+    });
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-123", email: "test@example.com" } },
+      error: null,
+    });
+
+    // Act
+    const user = await getVerifiedAuthUser();
+
+    // Assert
+    expect(user).toEqual({ id: "user-123", email: "test@example.com" });
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("getClaims が例外を投げた場合も getUser にフォールバックする", async () => {
+    // Arrange
+    mockGetClaims.mockRejectedValue(new Error("unexpected"));
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-123", email: "test@example.com" } },
+      error: null,
+    });
+
+    // Act
+    const user = await getVerifiedAuthUser();
+
+    // Assert
+    expect(user).toEqual({ id: "user-123", email: "test@example.com" });
+  });
+
+  it("未ログイン（getClaims も getUser もユーザーなし）の場合は null を返す", async () => {
+    // Arrange
+    mockGetClaims.mockResolvedValue({ data: null, error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error("Auth session missing"),
+    });
+
+    // Act
+    const user = await getVerifiedAuthUser();
+
+    // Assert
+    expect(user).toBeNull();
+  });
+
+  it("claims に email が無い場合は空文字で補完する", async () => {
+    // Arrange
+    mockGetClaims.mockResolvedValue({
+      data: { claims: { sub: "user-123" } },
+      error: null,
+    });
+
+    // Act
+    const user = await getVerifiedAuthUser();
+
+    // Assert
+    expect(user).toEqual({ id: "user-123", email: "" });
+  });
+});
+
+describe("createBackendAuthToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("検証済みユーザーの userId / email を含む JWT を発行する", async () => {
+    // Arrange
+    mockGetClaims.mockResolvedValue({
+      data: { claims: { sub: "user-123", email: "test@example.com" } },
+      error: null,
+    });
+
+    // Act
+    const token = await createBackendAuthToken();
+
+    // Assert
+    expect(token).not.toBeNull();
+    const payload = jwt.decode(token as string) as {
+      userId: string;
+      email: string;
+    };
+    expect(payload.userId).toBe("user-123");
+    expect(payload.email).toBe("test@example.com");
+  });
+
+  it("未認証の場合は null を返す", async () => {
+    // Arrange
+    mockGetClaims.mockResolvedValue({ data: null, error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error("Auth session missing"),
+    });
+
+    // Act
+    const token = await createBackendAuthToken();
+
+    // Assert
+    expect(token).toBeNull();
+  });
+});

--- a/frontend/src/lib/server/auth.ts
+++ b/frontend/src/lib/server/auth.ts
@@ -1,4 +1,3 @@
-import type { User } from "@supabase/supabase-js";
 import jwt from "jsonwebtoken";
 import type { UserSession } from "@/lib/auth";
 import { getCachedUserInfo } from "@/lib/server/cache";
@@ -34,7 +33,63 @@ export const buildApiUrl = (path: string) => {
   return `${HONO_API_BASE_URL}${normalizedPath}`;
 };
 
-const createBackendAuthTokenFromUser = (user: User | null) => {
+/** バックエンド用 JWT の発行に必要な最小限のユーザー情報 */
+export type AuthTokenUser = {
+  id: string;
+  email?: string | null;
+};
+
+/** 検証済みの認証ユーザー（アクセストークンの claims 由来） */
+export type VerifiedAuthUser = {
+  id: string;
+  email: string;
+};
+
+/**
+ * 現在のリクエストの認証ユーザーを検証して返す。
+ *
+ * `auth.getUser()` は毎回 Supabase Auth サーバーへの HTTP 往復が発生するため、
+ * まず `auth.getClaims()` で検証する。非対称署名キーのプロジェクトでは JWKS による
+ * ローカル検証となり（JWKS はモジュールレベルでキャッシュされ初回のみ取得）、
+ * HS256 等の対称キーの場合は getClaims 内部で getUser() に自動フォールバックする
+ * ため、どちらの構成でも挙動退行はない。
+ * getClaims が失敗した場合のみ、@supabase/ssr のトークンリフレッシュ経路を温存する
+ * ため getUser() を 1 回だけ試す。
+ */
+export const getVerifiedAuthUser =
+  async (): Promise<VerifiedAuthUser | null> => {
+    const supabase = await getServerSupabase();
+
+    try {
+      const { data, error } = await supabase.auth.getClaims();
+      if (!error && data?.claims?.sub) {
+        return {
+          id: data.claims.sub,
+          email: typeof data.claims.email === "string" ? data.claims.email : "",
+        };
+      }
+    } catch (claimsError) {
+      console.error(
+        "getVerifiedAuthUser: getClaims に失敗、getUser にフォールバックします:",
+        claimsError,
+      );
+    }
+
+    try {
+      const {
+        data: { user },
+        error,
+      } = await supabase.auth.getUser();
+      if (error || !user) {
+        return null;
+      }
+      return { id: user.id, email: user.email ?? "" };
+    } catch {
+      return null;
+    }
+  };
+
+const createBackendAuthTokenFromUser = (user: AuthTokenUser | null) => {
   if (!user) {
     return null;
   }
@@ -52,16 +107,13 @@ const createBackendAuthTokenFromUser = (user: User | null) => {
 };
 
 export const createBackendAuthToken = async () => {
-  const supabase = await getServerSupabase();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const user = await getVerifiedAuthUser();
   return createBackendAuthTokenFromUser(user);
 };
 
 export const fetchUserInfoFromHono = async (
   userId: string,
-  userOverride?: User | null,
+  userOverride?: AuthTokenUser | null,
 ): Promise<UserSession | null> => {
   const token =
     createBackendAuthTokenFromUser(userOverride ?? null) ||
@@ -113,15 +165,10 @@ export const fetchUserInfoFromHono = async (
 };
 
 export async function getCurrentUser(): Promise<UserSession | null> {
-  const supabase = await getServerSupabase();
-
   try {
-    const {
-      data: { user },
-      error,
-    } = await supabase.auth.getUser();
+    const user = await getVerifiedAuthUser();
 
-    if (error || !user) {
+    if (!user) {
       return null;
     }
 

--- a/frontend/src/lib/server/auth.ts
+++ b/frontend/src/lib/server/auth.ts
@@ -1,4 +1,5 @@
 import jwt from "jsonwebtoken";
+import { cache } from "react";
 import type { UserSession } from "@/lib/auth";
 import { getCachedUserInfo } from "@/lib/server/cache";
 import { getServerSupabase } from "@/lib/supabase/server";
@@ -164,7 +165,10 @@ export const fetchUserInfoFromHono = async (
   };
 };
 
-export async function getCurrentUser(): Promise<UserSession | null> {
+// React の cache() で同一 RSC レンダー内の呼び出しを 1 回にまとめる。
+// 例: mypage は AuthGate と MyPageInitializer の両方が getCurrentUser を呼ぶため、
+// ラップしないと認証検証とユーザー情報取得が二重に走る（Route Handler では no-op）。
+export const getCurrentUser = cache(async (): Promise<UserSession | null> => {
   try {
     const user = await getVerifiedAuthUser();
 
@@ -178,7 +182,7 @@ export async function getCurrentUser(): Promise<UserSession | null> {
     console.error("Unexpected error in getCurrentUser:", error);
     return null;
   }
-}
+});
 
 export async function getUserInfo(userId: string) {
   try {

--- a/frontend/src/lib/server/cache.ts
+++ b/frontend/src/lib/server/cache.ts
@@ -1,7 +1,6 @@
-import type { User } from "@supabase/supabase-js";
 import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 import type { UserSession } from "@/lib/auth";
-import { fetchUserInfoFromHono } from "@/lib/server/auth";
+import { type AuthTokenUser, fetchUserInfoFromHono } from "@/lib/server/auth";
 
 export const CACHE_TAG_USER_INFO = "user-info";
 
@@ -21,7 +20,7 @@ async function getCachedUserInfoInner(
   "use cache";
   cacheLife({ revalidate: 604800 });
   cacheTag(getUserInfoCacheTag(userId));
-  return fetchUserInfoFromHono(userId, { id: userId, email } as User);
+  return fetchUserInfoFromHono(userId, { id: userId, email });
 }
 
 /**
@@ -29,7 +28,7 @@ async function getCachedUserInfoInner(
  */
 export const getCachedUserInfo = async (
   userId: string,
-  user: User,
+  user: AuthTokenUser,
 ): Promise<UserSession | null> => {
   return getCachedUserInfoInner(userId, user.email ?? "");
 };

--- a/frontend/src/server/trpc/index.ts
+++ b/frontend/src/server/trpc/index.ts
@@ -1,16 +1,29 @@
 import { initTRPC, TRPCError } from "@trpc/server";
-import jwt from "jsonwebtoken";
-import { getServerSupabase } from "@/lib/supabase/server";
-
-const JWT_SECRET =
-  process.env.JWT_SECRET || "your-secret-key-change-in-production";
+import { createBackendAuthToken } from "@/lib/server/auth";
 
 export type TRPCContext = {
   req: Request;
+  /**
+   * リクエスト内で1回だけ認証検証とバックエンド用 JWT 発行を行う遅延メモ。
+   * httpBatchLink により 1 HTTP リクエストへ複数手続きが同乗するため、
+   * 手続きごとに Supabase への検証が重複しないようにする。
+   */
+  getAuthToken: () => Promise<string | null>;
 };
 
 type AuthenticatedContext = TRPCContext & {
   authToken: string;
+};
+
+export const createTRPCContext = (req: Request): TRPCContext => {
+  let authTokenPromise: Promise<string | null> | undefined;
+  return {
+    req,
+    getAuthToken: () => {
+      authTokenPromise ??= createBackendAuthToken();
+      return authTokenPromise;
+    },
+  };
 };
 
 const t = initTRPC.context<TRPCContext>().create({
@@ -23,32 +36,17 @@ export const createTRPCRouter = t.router;
 export const createCallerFactory = t.createCallerFactory;
 export const publicProcedure = t.procedure;
 
-export const authenticatedProcedure = t.procedure.use(async ({ next }) => {
-  const serverSupabase = await getServerSupabase();
-  const {
-    data: { user },
-    error,
-  } = await serverSupabase.auth.getUser();
+export const authenticatedProcedure = t.procedure.use(async ({ ctx, next }) => {
+  const authToken = await ctx.getAuthToken();
 
-  if (error || !user) {
+  if (!authToken) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
       message: "認証が必要です",
     });
   }
 
-  const authToken = jwt.sign(
-    {
-      userId: user.id,
-      email: user.email ?? "",
-    },
-    JWT_SECRET,
-    {
-      expiresIn: "24h",
-    },
-  );
-
   return next({
-    ctx: { authToken } as AuthenticatedContext,
+    ctx: { ...ctx, authToken } satisfies AuthenticatedContext,
   });
 });


### PR DESCRIPTION
## 変更概要

認証付き API 全体のレイテンシを削減するパフォーマンス改善です。

### Before

- `authenticatedProcedure`（34手続き: ソーシャルフィード・ユーザー情報・課金状態・通知・統計など）が、**リクエスト毎に `supabase.auth.getUser()` = Supabase Auth サーバーへの HTTP 往復**を実行
- `httpBatchLink` で 1 HTTP リクエストに複数手続きが同乗しても、tRPC はミドルウェアを手続きごとに実行するため、**バッチ内で `getUser()` が N 回並列に走る**
- `proxyToBackend`（カレンダーの exam-goals / training-dates-count 等）や RSC の `getCurrentUser`（AuthGate）も同様に毎回往復
- mypage では AuthGate と MyPageInitializer の両方が `getCurrentUser` を呼び、同一リクエスト内で検証+ユーザー情報取得が二重実行
- 皮肉なことに Hono バックエンド側は JWT ローカル検証で高速だった（フロント側だけが往復）

### After

- 新設の `getVerifiedAuthUser()` に認証検証を集約:
  1. まず `supabase.auth.getClaims()` で検証（**非対称署名キーなら WebCrypto + JWKS のローカル検証**。JWKS は auth-js のモジュールレベルキャッシュで初回のみ取得）
  2. 失敗時のみ `getUser()` に 1 回フォールバック（@supabase/ssr のトークンリフレッシュ経路を温存）
- tRPC コンテキストに遅延メモ `getAuthToken` を追加し、**バッチ内 N 手続きの検証 + バックエンド用 JWT 発行を 1 回に**
- `getCurrentUser` を React の `cache()` でラップし、**同一 RSC レンダー内の重複呼び出しを 1 回に**

## 影響範囲

- `frontend/src/server/trpc/index.ts` — authenticatedProcedure（34手続きは無変更で恩恵）
- `frontend/src/lib/server/auth.ts` — getVerifiedAuthUser 新設、createBackendAuthToken / getCurrentUser を置換、getCurrentUser の cache() 化
- `frontend/src/lib/server/cache.ts` — getCachedUserInfo の引数型を最小化（`as User` カスト解消）
- `frontend/src/app/api/trpc/[trpc]/route.ts` — createTRPCContext 利用

## 留意点

- HS256（対称キー）構成の場合、getClaims は内部で自動的に getUser() へフォールバックするため**どちらのキー構成でも挙動退行なし**
- getClaims はアクセストークンの失効（サインアウト・BAN）をトークン TTL（既定 1h）内は検知しません。これは Supabase 公式が推奨する標準的なトレードオフです
- 各 API Route（ai-coach, page-attachments 等）の直接 `getUser()` 呼び出しは本 PR のスコープ外（フォローアップ候補）

## テスト

- `auth.test.ts` 新規: getClaims 成功 / エラー時フォールバック / 例外時フォールバック / 未ログイン / email 欠落補完 / JWT ペイロード / 未認証 null の 7 ケース
- `pnpm check` / `pnpm test`（340件）/ `pnpm build` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qYWDDj3HCuMfEHXv5jqkt