### PR TITLE
chore: 一覧→詳細の即時表示・日次上限の並列取得などデータ取得を改善

### DIFF
--- a/frontend/src/app/[locale]/(authenticated)/(tabbed)/(default-header)/personal/pages/[page_id]/PageDetail.tsx
+++ b/frontend/src/app/[locale]/(authenticated)/(tabbed)/(default-header)/personal/pages/[page_id]/PageDetail.tsx
@@ -36,7 +36,7 @@ export function PageDetail() {
     attachments,
     isErrorWithoutCache,
     refetch,
-  } = usePageDetailData(pageId);
+  } = usePageDetailData(pageId, { seedFromListCache: true });
 
   const { showToast } = useToast();
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);

--- a/frontend/src/lib/hooks/useDailyLimits.ts
+++ b/frontend/src/lib/hooks/useDailyLimits.ts
@@ -33,7 +33,11 @@ export function useDailyLimits() {
 
   const query = useQuery<DailyLimitsData, Error>({
     queryKey: dailyLimitsQueryKey(user?.id),
-    enabled: !!user?.id && !subLoading && !isPremium,
+    // subscription の完了を待たずに並列で取得する（auth → subscription → dailyLimits の
+    // 3段直列を解消）。subscription 解決前に Premium ユーザーへ 1 回だけ無駄な取得が
+    // 走り得るが、結果は使われないため表示への影響はない（loading は従来どおり
+    // subLoading を含むので、Premium 判定前に Free 用の値が見えることもない）
+    enabled: !!user?.id && !isPremium,
     queryFn: async () => {
       try {
         return await getDailyLimits();

--- a/frontend/src/lib/hooks/usePageDetailData.ts
+++ b/frontend/src/lib/hooks/usePageDetailData.ts
@@ -1,4 +1,8 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type InfiniteData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useCallback } from "react";
 import type { AttachmentData } from "@/components/features/personal/AttachmentCard/AttachmentCard";
 import { getAttachments, getPage } from "@/lib/api/client";
@@ -13,12 +17,48 @@ export const pageDetailQueryKey = (
 export const pageAttachmentsQueryKey = (pageId: string) =>
   ["page-attachments", pageId] as const;
 
-export function usePageDetailData(pageId: string) {
+// useTrainingPagesData の無限スクロールキャッシュ（["training-pages", userId, options]）の
+// 1ページ分。placeholder 探索に必要な部分だけを構造的に型定義する
+type TrainingPagesListPage = {
+  training_pages: TrainingPageData[];
+};
+
+interface UsePageDetailDataOptions {
+  /**
+   * 一覧キャッシュに同じページがあれば placeholderData として即表示する
+   * （詳細 API の往復を待たずに一覧→詳細の遷移を待機ゼロにする）。
+   * placeholder はキャッシュに書き込まれないため他画面には影響しないが、
+   * 編集画面（PageEdit）はフォーム初期値をサーバー取得値で確定させる必要が
+   * あるため有効化しないこと。
+   */
+  seedFromListCache?: boolean;
+}
+
+export function usePageDetailData(
+  pageId: string,
+  { seedFromListCache = false }: UsePageDetailDataOptions = {},
+) {
   const { user, loading: authLoading } = useAuth();
   const queryClient = useQueryClient();
 
+  // 一覧キャッシュ（フィルタ違いを含む全エントリ）から該当ページを探す
+  const findPageInListCache = useCallback((): TrainingPageData | undefined => {
+    if (!seedFromListCache || !pageId || !user?.id) return undefined;
+    const entries = queryClient.getQueriesData<
+      InfiniteData<TrainingPagesListPage>
+    >({ queryKey: ["training-pages", user.id] });
+    for (const [, data] of entries) {
+      const found = data?.pages
+        ?.flatMap((listPage) => listPage.training_pages)
+        .find((listPage) => listPage.id === pageId);
+      if (found) return found;
+    }
+    return undefined;
+  }, [seedFromListCache, pageId, user?.id, queryClient]);
+
   const pageQuery = useQuery({
     queryKey: pageDetailQueryKey(pageId, user?.id),
+    placeholderData: () => findPageInListCache(),
     queryFn: async (): Promise<TrainingPageData | null> => {
       if (!pageId || !user?.id) return null;
       const response = await getPage(pageId, user.id);
@@ -45,6 +85,10 @@ export function usePageDetailData(pageId: string) {
 
   const attachmentsQuery = useQuery({
     queryKey: pageAttachmentsQueryKey(pageId),
+    // 一覧レスポンスは添付も含むため、同じページの添付を placeholder に使う
+    // （type はリテラル union へ狭める。値は同一 API 由来で "image"|"video"|"youtube" のみ）
+    placeholderData: () =>
+      findPageInListCache()?.attachments as AttachmentData[] | undefined,
     queryFn: async (): Promise<AttachmentData[]> => {
       if (!pageId) return [];
       const attachJson = await getAttachments(pageId);

--- a/frontend/src/lib/hooks/useTrainingPagesData.ts
+++ b/frontend/src/lib/hooks/useTrainingPagesData.ts
@@ -235,8 +235,8 @@ export function useTrainingPagesData(options: FetchOptions = {}) {
       );
     },
     onSettled: () => {
-      // 全ての training-pages キャッシュを無効化（フィルタ違いも含めて次回参照時に最新化）
-      queryClient.invalidateQueries({ queryKey: ["training-pages"] });
+      // 自ユーザーの training-pages キャッシュのみ無効化（フィルタ違いも含めて次回参照時に最新化）
+      queryClient.invalidateQueries({ queryKey: ["training-pages", user?.id] });
     },
   });
 


### PR DESCRIPTION
## 変更概要

体感レスポンスに効く小粒のデータ取得改善を3点まとめた PR です。

### 1. 稽古記録の一覧→詳細タップを「待機ゼロ」に（`usePageDetailData`）

一覧（無限スクロール）のキャッシュには詳細表示に必要なデータ（title / content / tags / memos / attachments）がすべて含まれているのに、詳細画面はスケルトンを出して詳細 API + 添付 API の応答を待っていました。

一覧キャッシュから該当ページを探して `placeholderData` に供給することで、**タップした瞬間に内容が表示**され、裏で最新データに置き換わります。

- opt-in 方式（`seedFromListCache: true`）で、有効化したのは閲覧用の PageDetail のみ
- `placeholderData` は React Query のキャッシュに書き込まれないため、**フォーム初期値をサーバー取得値で確定させたい編集画面（PageEdit）には影響しない**（今後一覧レスポンスの content が切詰められても編集データ破損が起きない設計）

### 2. 日次上限の取得を subscription と並列化（`useDailyLimits`）

これまで `auth → subscription 取得 → dailyLimits 取得` の3段直列で、SNS フィードのスワイプ有効化（`enabled: !dailyLimitsLoading`）や投稿ボタンの活性がこのチェーン完了までブロックされていました。`enabled` から `!subLoading` を外して並列化し、待ち時間を「合計」から「最大値」に短縮します。

- `loading` の計算は従来どおり subLoading を含むため、**Premium 判定前に Free 用の上限値が UI に見えることはありません**
- Premium ユーザーに subscription 解決前の 1 回だけ無駄な取得が走り得ますが、結果は使われません

### 3. 削除後の invalidate を自ユーザーにスコープ（`useTrainingPagesData`）

`["training-pages"]` 全体ではなく `["training-pages", user.id]` のみ無効化するように変更。

## 影響範囲

- `frontend/src/lib/hooks/usePageDetailData.ts` / `PageDetail.tsx`
- `frontend/src/lib/hooks/useDailyLimits.ts`（SocialPostsFeed のスワイプ・投稿系 UI）
- `frontend/src/lib/hooks/useTrainingPagesData.ts`

## テスト

- `pnpm check` / `pnpm test`（333件）/ `pnpm build` すべてパス
- 手動確認推奨: 一覧→詳細遷移（Network throttling で顕著）、編集画面のフォーム初期値がサーバー値であること、SNS フィード初期表示直後のスワイプ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qYWDDj3HCuMfEHXv5jqkt