### PR TITLE
chore: フォントを next/font 化し render-blocking な外部 CSS を排除

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,34 @@
 import type { Metadata, Viewport } from "next";
+import { Inter, Noto_Sans_JP, Zen_Old_Mincho } from "next/font/google";
 import Script from "next/script";
 import { ServiceWorkerRegister } from "@/components/shared/ServiceWorkerRegister/ServiceWorkerRegister";
 import "../styles/globals.css";
+
+// Google Fonts の render-blocking <link rel="stylesheet"> を next/font のセルフホスト配信に置換。
+// woff2 は _next/static/media から同一オリジンで配信され、クリティカルパスの外部 CSS が消える。
+// 各 variable は variables.css の --font-* スタック先頭で参照される。
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  display: "swap",
+  variable: "--next-font-inter",
+});
+
+// 日本語フォントはサブセットが多数の woff2 に分割されるため preload せず、
+// unicode-range による必要範囲のみのオンデマンド取得に任せる
+const notoSansJP = Noto_Sans_JP({
+  weight: ["400", "500", "700"],
+  display: "swap",
+  preload: false,
+  variable: "--next-font-noto-sans-jp",
+});
+
+const zenOldMincho = Zen_Old_Mincho({
+  weight: ["400", "700"],
+  display: "swap",
+  preload: false,
+  variable: "--next-font-zen-old-mincho",
+});
 
 const cloudFrontDomain = process.env.NEXT_PUBLIC_CLOUDFRONT_DOMAIN;
 
@@ -93,14 +120,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ja" suppressHydrationWarning>
+    <html
+      lang="ja"
+      suppressHydrationWarning
+      className={`${inter.variable} ${notoSansJP.variable} ${zenOldMincho.variable}`}
+    >
       <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
         {/* CloudFront（添付画像・動画・プロフィール画像の配信元）への接続を事前確立し、初回リソースの DNS/TLS 待ちを短縮 */}
         {cloudFrontDomain && (
           <>
@@ -112,10 +137,6 @@ export default function RootLayout({
             <link rel="dns-prefetch" href={`https://${cloudFrontDomain}`} />
           </>
         )}
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&family=Zen+Old+Mincho:wght@400;700&display=swap"
-          rel="stylesheet"
-        />
       </head>
       <body suppressHydrationWarning>
         <script

--- a/frontend/src/styles/variables.css
+++ b/frontend/src/styles/variables.css
@@ -60,21 +60,26 @@
   --lp-cta-inquiry-text: #2c2c2c;
   --lp-border: #2c2c2c;
 
-  /* ── フォント変数 ── */
+  /* ── フォント変数 ──
+     先頭の var(--next-font-*) は next/font（app/layout.tsx）が <html> に注入する
+     セルフホストフォント。next/font を通らない環境（Storybook 等）でも
+     font-family が無効化されないよう、第2引数に従来のファミリー名を残す */
   --font-zen-old-mincho:
-    "Zen Old Mincho", "Times New Roman", "Noto Serif JP", serif;
+    var(--next-font-zen-old-mincho, "Zen Old Mincho"), "Times New Roman",
+    "Noto Serif JP", serif;
   --font-noto-sans-jp:
-    "Noto Sans JP", "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Meiryo",
-    sans-serif;
+    var(--next-font-noto-sans-jp, "Noto Sans JP"), "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "Meiryo", sans-serif;
   --font-inter:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-    "Helvetica Neue", Arial, sans-serif;
+    var(--next-font-inter, "Inter"), -apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
 
   /* ── デザイントークン（フォントファミリー） ── */
-  --font-brand: "Zen Old Mincho", "Times New Roman", "Noto Serif JP", serif;
+  --font-brand: var(--font-zen-old-mincho);
   --font-ui:
-    "Inter", "Noto Sans JP", "Hiragino Sans", "Hiragino Kaku Gothic ProN",
-    "Meiryo", sans-serif;
+    var(--next-font-inter, "Inter"),
+    var(--next-font-noto-sans-jp, "Noto Sans JP"), "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "Meiryo", sans-serif;
 
   /* ── フォントサイズ変数 ── */
   --font-size-small: 14px;


### PR DESCRIPTION
## 変更概要

全ページ共通の初回描画を改善するフォント読み込みの最適化です。

### Before

`<link rel="stylesheet" href="https://fonts.googleapis.com/css2?...">` が **render-blocking リソース**としてクリティカルパスに乗っており、初回描画が

```
HTML → fonts.googleapis.com（CSS 取得・外部）→ fonts.gstatic.com（woff2 取得・外部）
```

の外部2段フェッチにブロックされていました。

### After

`next/font/google` によるセルフホスト配信に移行:

- **woff2 は `_next/static/media` から同一オリジン配信**（ビルド時に取得・375ファイル、unicode-range 分割）。外部オリジンへの接続確立（DNS/TLS）が丸ごと消えます
- @font-face 定義はページの CSS チャンクに同梱され、外部 CSS への依存が消滅（ビルド成果物で fonts.googleapis.com 参照ゼロを確認済み）
- **Inter**: latin サブセットを preload（LCP テキスト用）
- **Noto Sans JP / Zen Old Mincho**: `preload: false`。日本語フォントは多数の woff2 に分割されるため、unicode-range によるオンデマンド取得に任せます
- 不要になった fonts.googleapis.com / fonts.gstatic.com への preconnect を削除

### CSS 変数の接続

`variables.css` の `--font-inter` / `--font-noto-sans-jp` / `--font-zen-old-mincho` / `--font-ui` / `--font-brand` のスタック先頭を `var(--next-font-*)` に置換。**利用側の CSS Modules（50ファイル超）は無変更**で恩恵を受けます。

- next/font を通らない環境（Storybook 等）でも `font-family` が無効化されないよう、`var()` の第2引数に従来のファミリー名を残しています（Storybook は従来から Google Fonts を読み込んでいないため見た目は不変）

## 影響範囲

- 全ページ（LP・アプリ内すべて）のフォント配信経路
- フォントファミリー・ウェイト構成（Inter 400/500/700, Noto Sans JP 400/500/700, Zen Old Mincho 400/700）は従来と同一のため見た目の変化はありません

## 検証

- `pnpm build` パス。ビルド成果物で以下を確認済み:
  - `<html>` に3書体の variable クラスが付与される
  - fonts.googleapis.com への参照が 0 件
  - `_next/static/media/*.woff2` 375 ファイル生成、@font-face が同一オリジン CSS チャンクに出力
- `pnpm check` / `pnpm test` パス
- マージ後推奨: 日本語 LP・英語 LP・アプリ内の明朝見出し（--font-brand）の目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qYWDDj3HCuMfEHXv5jqkt