### PR TITLE
chore: ページ保存のタグ N+1 解消・一覧本文の切詰め・道場検索のキャッシュ化

### DIFF
--- a/backend/src/lib/supabase.ts
+++ b/backend/src/lib/supabase.ts
@@ -105,47 +105,64 @@ export type TrainingPageMemoInput = {
 const tagMapKey = (category: string, name: string): string =>
   `${category}\u001f${name}`;
 
-// 指定された (name, category) のタグが無ければ作成し、キー→UserTag の Map を返す
+// 指定された (name, category) のタグが無ければ作成し、キー→UserTag の Map を返す。
+// 既存チェックは .in() の一括 SELECT、不足分は一括 INSERT の計2クエリで解決する
+// （従来はタグ毎に SELECT + INSERT を発行する N+1 で、タグ6個の保存で最大12往復だった）
 const ensureUserTags = async (
   userId: string,
   tagRefs: { name: string; category: string }[],
 ): Promise<Map<string, UserTagRow>> => {
   const map = new Map<string, UserTagRow>();
+  if (tagRefs.length === 0) {
+    return map;
+  }
+
+  const { data: existingTags, error: selectError } = await supabase
+    .from("UserTag")
+    .select("*")
+    .eq("user_id", userId)
+    .in("name", [...new Set(tagRefs.map((t) => t.name))]);
+
+  if (selectError) {
+    throw new Error(`タグの検索に失敗しました: ${selectError.message}`);
+  }
+
+  for (const tag of existingTags ?? []) {
+    map.set(tagMapKey(tag.category, tag.name), tag);
+  }
+
+  const missingKeys = new Set<string>();
+  const missing: { name: string; category: string }[] = [];
   for (const { name, category } of tagRefs) {
     const key = tagMapKey(category, name);
-    if (map.has(key)) continue;
+    if (map.has(key) || missingKeys.has(key)) continue;
+    missingKeys.add(key);
+    missing.push({ name, category });
+  }
 
-    const { data: existingTag } = await supabase
+  if (missing.length > 0) {
+    const createdAt = new Date().toISOString();
+    const { data: newTags, error: insertError } = await supabase
       .from("UserTag")
-      .select("*")
-      .eq("user_id", userId)
-      .eq("name", name)
-      .eq("category", category)
-      .single();
-
-    if (existingTag) {
-      map.set(key, existingTag);
-      continue;
-    }
-
-    const { data: newTag, error } = await supabase
-      .from("UserTag")
-      .insert([
-        {
+      .insert(
+        missing.map(({ name, category }) => ({
           user_id: userId,
           name,
           category,
-          created_at: new Date().toISOString(),
-        },
-      ])
-      .select("*")
-      .single();
+          created_at: createdAt,
+        })),
+      )
+      .select("*");
 
-    if (error) {
-      throw new Error(`タグの作成に失敗しました: ${error.message}`);
+    if (insertError) {
+      throw new Error(`タグの作成に失敗しました: ${insertError.message}`);
     }
-    map.set(key, newTag);
+
+    for (const tag of newTags ?? []) {
+      map.set(tagMapKey(tag.category, tag.name), tag);
+    }
   }
+
   return map;
 };
 
@@ -424,53 +441,18 @@ export const createTrainingPage = async (
       ([category, names]) => names.map((name) => ({ name, category })),
     );
 
+    // 3. タグを一括解決（既存は取得・不足分は作成）し、リレーションを準備
+    const tagMap = await ensureUserTags(pageData.user_id, categories);
+
     const associatedTags: UserTagRow[] = [];
     const trainingPageTags: Omit<TrainingPageTagRow, "id">[] = [];
-
-    // 3. 各タグを処理
     for (const { name, category } of categories) {
-      // 既存のタグをチェック
-      const { data: existingTag } = await supabase
-        .from("UserTag")
-        .select("*")
-        .eq("user_id", pageData.user_id)
-        .eq("name", name)
-        .eq("category", category)
-        .single();
-
-      let tagId: string;
-
-      if (existingTag) {
-        // 既存のタグを使用
-        tagId = existingTag.id;
-        associatedTags.push(existingTag);
-      } else {
-        // 新しいタグを作成
-        const { data: newTag, error: tagError } = await supabase
-          .from("UserTag")
-          .insert([
-            {
-              user_id: pageData.user_id,
-              name,
-              category,
-              created_at: new Date().toISOString(),
-            },
-          ])
-          .select("*")
-          .single();
-
-        if (tagError) {
-          throw new Error(`タグの作成に失敗しました: ${tagError.message}`);
-        }
-
-        tagId = newTag.id;
-        associatedTags.push(newTag);
-      }
-
-      // TrainingPageTagのリレーションを準備
+      const tag = tagMap.get(tagMapKey(category, name));
+      if (!tag) continue;
+      associatedTags.push(tag);
       trainingPageTags.push({
         training_page_id: newPage.id,
-        user_tag_id: tagId,
+        user_tag_id: tag.id,
       });
     }
 
@@ -1253,53 +1235,18 @@ export const updateTrainingPage = async (
       ([category, names]) => names.map((name) => ({ name, category })),
     );
 
+    // 5. タグを一括解決（既存は取得・不足分は作成）し、リレーションを準備
+    const tagMap = await ensureUserTags(pageData.user_id, categories);
+
     const associatedTags: UserTagRow[] = [];
     const trainingPageTags: Omit<TrainingPageTagRow, "id">[] = [];
-
-    // 5. 各タグを処理
     for (const { name, category } of categories) {
-      // 既存のタグをチェック
-      const { data: existingTag } = await supabase
-        .from("UserTag")
-        .select("*")
-        .eq("user_id", pageData.user_id)
-        .eq("name", name)
-        .eq("category", category)
-        .single();
-
-      let tagId: string;
-
-      if (existingTag) {
-        // 既存のタグを使用
-        tagId = existingTag.id;
-        associatedTags.push(existingTag);
-      } else {
-        // 新しいタグを作成
-        const { data: newTag, error: tagError } = await supabase
-          .from("UserTag")
-          .insert([
-            {
-              user_id: pageData.user_id,
-              name,
-              category,
-              created_at: new Date().toISOString(),
-            },
-          ])
-          .select("*")
-          .single();
-
-        if (tagError) {
-          throw new Error(`タグの作成に失敗しました: ${tagError.message}`);
-        }
-
-        tagId = newTag.id;
-        associatedTags.push(newTag);
-      }
-
-      // TrainingPageTagのリレーションを準備
+      const tag = tagMap.get(tagMapKey(category, name));
+      if (!tag) continue;
+      associatedTags.push(tag);
       trainingPageTags.push({
         training_page_id: updatedPage.id,
-        user_tag_id: tagId,
+        user_tag_id: tag.id,
       });
     }
 

--- a/backend/src/routes/pages/index.ts
+++ b/backend/src/routes/pages/index.ts
@@ -24,6 +24,10 @@ import {
 
 const app = new Hono();
 
+// 一覧レスポンスの本文プレビュー長。一覧カードは CSS line-clamp のスニペット表示のため
+// 全文は不要（長文ページでペイロードが肥大するのを防ぐ）。詳細 GET /:id は全文を返す
+const LIST_CONTENT_PREVIEW_LENGTH = 500;
+
 // ページ作成API
 app.post("/", zValidator("json", createPageSchema), async (c) => {
   try {
@@ -149,7 +153,7 @@ app.get("/", zValidator("query", getPagesSchema), async (c) => {
       page: {
         id: page.id,
         title: page.title,
-        content: page.content,
+        content: page.content.slice(0, LIST_CONTENT_PREVIEW_LENGTH),
         content_mode: page.content_mode ?? "free",
         user_id: page.user_id,
         is_public: page.is_public,

--- a/backend/src/routes/pages/pages.test.ts
+++ b/backend/src/routes/pages/pages.test.ts
@@ -682,6 +682,46 @@ describe("ページ一覧取得API", () => {
     expect(responseBody.data.training_pages[1].tags).toHaveLength(0);
   });
 
+  it("一覧レスポンスでは500文字を超えるcontentが先頭500文字に切り詰められる", async () => {
+    // Arrange
+    const longContent = "あ".repeat(600);
+    vi.spyOn(supabaseModule, "getTrainingPages").mockResolvedValue({
+      pages: [
+        {
+          page: {
+            id: "test-page-id-long",
+            title: "長文ページ",
+            content: longContent,
+            user_id: "test-user-id",
+            is_public: false,
+            created_at: "2023-01-01T00:00:00.000Z",
+            updated_at: "2023-01-01T00:00:00.000Z",
+          },
+          tags: [],
+        },
+      ],
+      totalCount: 1,
+    });
+
+    const request = new Request(
+      "http://localhost/?user_id=test-user-id&limit=20",
+      {
+        method: "GET",
+      },
+    );
+
+    // Act
+    const response = await app.fetch(request);
+    const responseBody = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(responseBody.data.training_pages[0].page.content).toHaveLength(500);
+    expect(responseBody.data.training_pages[0].page.content).toBe(
+      longContent.slice(0, 500),
+    );
+  });
+
   it("user_idが未指定の場合にバリデーションエラーが返されること", async () => {
     // Arrange & Act
     const request = new Request("http://localhost/?limit=20", {

--- a/frontend/src/server/trpc/hono.ts
+++ b/frontend/src/server/trpc/hono.ts
@@ -29,11 +29,17 @@ const extractErrorMessage = (payload: unknown): string | null => {
 
 export async function callHonoApi<T>(
   path: string,
-  options: RequestInit = {},
+  options: RequestInit & {
+    /**
+     * 指定時は cache: "no-store" の代わりに Next.js Data Cache へ載せる（秒）。
+     * 道場マスタ検索のようなユーザー非依存・準静的な GET のみで使うこと
+     */
+    revalidate?: number;
+  } = {},
 ): Promise<T> {
   const url = buildApiUrl(path);
 
-  const { headers: customHeaders, ...otherOptions } = options;
+  const { headers: customHeaders, revalidate, ...otherOptions } = options;
 
   let response: Response;
   try {
@@ -43,7 +49,9 @@ export async function callHonoApi<T>(
         "X-App-Url": getBaseUrl(),
         ...customHeaders,
       },
-      cache: "no-store",
+      ...(revalidate != null
+        ? { next: { revalidate } }
+        : { cache: "no-store" as const }),
       ...otherOptions,
     });
   } catch (err) {

--- a/frontend/src/server/trpc/procedures.ts
+++ b/frontend/src/server/trpc/procedures.ts
@@ -509,6 +509,8 @@ export const searchDojoStylesProcedure = publicProcedure
 
     return callHonoApi<ApiResponse<DojoStyleSearchResult[]>>(
       `/api/dojo-styles/search?${query.toString()}`,
+      // 道場マスタはユーザー非依存の準静的データのため Data Cache で 1 時間共有する
+      { revalidate: 3600 },
     );
   });
 


### PR DESCRIPTION
## 変更概要

バックエンドのクエリ効率とレスポンスペイロードを改善する PR です。

### 1. ページ保存時のタグ解決 N+1 を解消（`backend/src/lib/supabase.ts`）

タグの存在確認と作成が**タグ1個につき SELECT + INSERT の個別クエリ**になっており、タグ6個のページ保存で最大12往復が発生していました（Cloudflare Workers → Supabase はリージョン間通信のため往復コストが大きい）。

- `ensureUserTags` を `.in()` の一括 SELECT + 不足分の一括 INSERT の**計2クエリ**に書き換え
- `createTrainingPage` / `updateTrainingPage` に重複していた同型のループを削除し、`ensureUserTags` の再利用に統一
- これにより**ページ作成・ページ更新・tag_based メモ保存の3経路すべて**で N+1 が解消。「保存」ボタンを押してから完了までの待ち時間が短縮されます

挙動差分: 従来はタグ存在確認の SELECT エラーを握り潰して INSERT に進んでいましたが、新実装ではエラーを throw します（より安全側）。

### 2. 一覧レスポンスの content を先頭500文字に切詰め（`backend/src/routes/pages/index.ts`）

一覧カード（TrainingCard）は CSS line-clamp によるスニペット表示のため全文は不要ですが、全文を毎回転送していました。長文の稽古記録を書き込むユーザーほど一覧のペイロードとシリアライズコストが膨らむため、一覧 GET のみ先頭500文字に切詰めます。

- 詳細 `GET /:id` は従来どおり全文を返すため、詳細・編集画面に影響なし
- #336 の placeholder シードとの組合せでは「詳細を開いた瞬間は先頭500文字 → 直後に全文へ置換」となります（閲覧上は視認困難な一瞬）

### 3. 道場マスタ検索を Data Cache で共有（`frontend/src/server/trpc/hono.ts` / `procedures.ts`)

`callHonoApi` に `revalidate` オプションを追加し、ユーザー非依存・準静的な `dojoStyles.search` のみ Next.js Data Cache で 1 時間キャッシュ。プロフィール編集の道場名オートコンプリートで同じ検索語が Hono/Supabase まで到達しなくなります。

## 影響範囲

- ページ作成・更新の保存処理（レスポンス形状は不変）
- 稽古記録一覧 API のレスポンス（content 長のみ変化。唯一の消費元 `useTrainingPagesData` はスニペット表示のため影響なし）
- 道場名検索（最大1時間の鮮度遅延を許容。新規道場登録は authenticatedProcedure 経由で対象外）

## テスト

- backend: `pnpm test` 237件パス（一覧 content 切詰めのテストを新規追加）
- frontend: `pnpm check` / `tsc --noEmit` / `pnpm build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qYWDDj3HCuMfEHXv5jqkt